### PR TITLE
Restore build time map extraction;  Remove unused module std::process::Command;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN rm /rust/src/*.rs
 # Download the map dataset, extraction will occur in-container to reduce image size
 WORKDIR /maps
 RUN wget https://storage.googleapis.com/super-metroid-map-rando/maps/session-2023-06-08T14:55:16.779895.pkl-bk24-subarea-balance-2.tgz \
-    -O maps.tar.gz
-# Keeping this as backup in case in-container extraction breaks
-# RUN tar xfz maps.tar.gz --directory /maps --strip-components 1 && rm maps.tar.gz
+    -O maps.tar.gz \
+    && tar xfz maps.tar.gz --directory /maps \
+    && rm maps.tar.gz
 
 # Now copy over everything else and build the real binary
 COPY rust /rust

--- a/rust/src/bin/maprando-web.rs
+++ b/rust/src/bin/maprando-web.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::process::Command;
 use std::thread;
 use std::time::SystemTime;
 


### PR DESCRIPTION
Would build but not run for me.  I assume you already have a copy of `session*balance-2/` extracted locally that made it work for you since it would just be copied over with the rest of `static`.

```
Attaching to map_rando
map_rando  | thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2)', src/bin/maprando-web.rs:1563:55
map_rando  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
map_rando exited with code 101
```