### PR TITLE
Fix to compiler warnings

### DIFF
--- a/rust/src/bin/maprando-web.rs
+++ b/rust/src/bin/maprando-web.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::process::Command;
 use std::thread;
 use std::time::SystemTime;
 
@@ -306,7 +305,7 @@ struct SeedHeaderTemplate<'a> {
     early_filler_items: Vec<String>,
     item_placement_style: String,
     difficulty: &'a DifficultyConfig,
-    notable_strats: Vec<String>,
+    _notable_strats: Vec<String>,
     quality_of_life_preset: String,
     supers_double: bool,
     mother_brain_fight: String,
@@ -414,7 +413,7 @@ fn render_seed(
             .collect(),
         item_placement_style: format!("{:?}", seed_data.difficulty.item_placement_style),
         difficulty: &seed_data.difficulty,
-        notable_strats,
+        _notable_strats: notable_strats,
         quality_of_life_preset: seed_data
             .quality_of_life_preset
             .clone()

--- a/rust/src/customize/room_palettes.rs
+++ b/rust/src/customize/room_palettes.rs
@@ -195,7 +195,7 @@ fn fix_mother_brain(rom: &mut Rom, game_data: &GameData) -> Result<()> {
 }
 
 struct AllocatorBlock {
-    start_addr: usize,
+    _start_addr: usize,
     end_addr: usize,
     current_addr: usize
 }
@@ -208,7 +208,7 @@ impl Allocator {
     pub fn new(blocks: Vec<(usize, usize)>) -> Self {
         Allocator {
             blocks: blocks.into_iter().map(|(start, end)| AllocatorBlock {
-                start_addr: start,
+                _start_addr: start,
                 end_addr: end,
                 current_addr: start,
             }).collect()

--- a/rust/src/game_data.rs
+++ b/rust/src/game_data.rs
@@ -2481,7 +2481,7 @@ impl GameData {
             1, // Red Crateria
             15, 16, 17, 18, 19, 20  // Ceres
         ];
-        for (area_idx, area) in [
+        for (_area_idx, area) in [
             "crateria",
             "brinstar",
             "norfair",
@@ -2511,8 +2511,8 @@ impl GameData {
 
                 let gfx16x16_path = tileset_path.join("16x16tiles.ttb");
                 let gfx16x16_bytes = std::fs::read(gfx16x16_path)?;
-                
-                pal_map.insert(tileset_idx, ThemedTileset { 
+
+                pal_map.insert(tileset_idx, ThemedTileset {
                     palette,
                     gfx8x8: gfx8x8_bytes,
                     gfx16x16: gfx16x16_bytes,

--- a/rust/src/patch.rs
+++ b/rust/src/patch.rs
@@ -1010,7 +1010,7 @@ impl<'a> Patcher<'a> {
                     // We want it to behave like the other Refill rooms and use area-themed music.
                     continue;
                 }
-                let mut new_song = area_music[area][subarea];
+                let new_song = area_music[area][subarea];
                 // if room.name == "Landing Site" {
                 //     // Set all Landing Site states to use the same track, the one that plays in vanilla before
                 //     // Power Bombs but after Zebes is awake:
@@ -1620,7 +1620,7 @@ impl<'a> Patcher<'a> {
             // East Pants Room
             write_asm(room.twin_rom_address.unwrap(), x % 16, y % 16 + 16);
         }
-        
+
         Ok(())
     }
 
@@ -1638,8 +1638,7 @@ impl<'a> Patcher<'a> {
         let mut next_state_index: usize = 0;
         let mut state_idxs: Vec<usize> = vec![];
 
-        for door in &self.randomization.locked_doors {
-            let mut door = *door;
+        for _door in &self.randomization.locked_doors {
             while reserved_state_indexes.contains(&next_state_index) {
                 next_state_index += 1;
             }

--- a/rust/src/web/logic.rs
+++ b/rust/src/web/logic.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use glob::glob;
 use hashbrown::{HashMap, HashSet};

--- a/rust/templates/logic/room.stpl
+++ b/rust/templates/logic/room.stpl
@@ -38,7 +38,6 @@ document.getElementById("navigation-logic").classList.add("active");
         </div>
         <div class="col-lg-9 my-2 btn-group overflow-auto" role="group">
         <% for (i, difficulty) in difficulty_names.iter().enumerate() { 
-            let name_no_space = &difficulty.replace(" ", "");
             let checked = if i == difficulty_names.len() - 1 { "checked" } else { "" }; 
             %>
             <input type="radio" class="btn-check difficulty-filter" name="preset" value="<%= i %>"


### PR DESCRIPTION
warning: unused import: `std::process::Command` --> src/bin/maprando-web.rs:2:5

warning: unused variable: `notable_strats` --> src/bin/maprando-web.rs:308:5

warning: field `start_addr` is never read --> src/customize/room_palettes.rs:198:5

warning: unused variable: `area_idx` --> src/game_data.rs:2484:14

warning: unused variable: `door` --> src/patch.rs:1642:21
warning: variable does not need to be mutable --> src/patch.rs:1642:17
  NOTE: Line 1641 changed from `for door` to `for _door` as well

warning: variable does not need to be mutable --> src/patch.rs:1013:21
  NOTE: Commented out code below this would require `mut` if reinstated unless folded into initialization ternary-style
  e.g. `let new_song = if room.name != "Landing Site" { area_music[area][subarea] } else { 0x0606 };`

warning: unused import: `Path` --> src/web/logic.rs:1:17

warning: unused variable: `name_no_space` --> /rust/target/release/build/sailfish-compiler-4c1b9b72b1c17739/out/templates/room-eb0b5fdf3a787627:1:10114
  NOTE: Root cause was in `templates/logic/room.stpl`: Removed line 41 `let name_no_space = &difficulty.replace(" ", "");`

NOTE:
There are 6 "unused variable" warnings left in src/web/logic.rs

Most of these are "used" in the sense that they are cloned, however it seems that rust doesn't count that as a "use"

Adding `#[allow(unused_variables)]` before the properties does not work, and from what i can tell they're still working on fully implementing attributes for expressions/structs/etc (https://github.com/rust-lang/rust/issues/15701)

Adding the `#![allow(unused_variables)]` attribute to the top of the file silences these, but it's too broad as it covers the whole file