### PR TITLE
Add track list info to MSU patch

### DIFF
--- a/patches/src/msu1.asm
+++ b/patches/src/msu1.asm
@@ -1,4 +1,51 @@
-;;; Based on https://raw.githubusercontent.com/theonlydude/RandomMetroidSolver/master/patches/common/src/supermetroid_msu1.asm
+; Track List:
+;
+; 1 - Apperance fanfare
+; 2 - Item acquired (Unused)
+; 3 - Item/elevator room
+; 4 - Opening with intro
+; 5 - Opening without intro
+; 6 - Crateria - First landing (with thunder)
+; 7 - Crateria - First landing (without thunder)
+; 8 - Crateria - Space Pirates Appear
+; 9 - Crateria - Golden statues room
+; 10 - Theme of Samus Aran (Samus's Ship & East Crateria)
+; 11 - Green Brinstar
+; 12 - Red Brinstar
+; 13 - Upper Norfair
+; 14 - Lower Norfair
+; 15 - Inner Maridia
+; 16 - Outer Maridia
+; 17 - Tourian
+; 18 - Mother Brain battle
+; 19 - Big Boss Battle 1 (Chozo statues, Ridley, and Draygon)
+; 20 - Evacuation
+; 21 - Chozo statue awakens
+; 22 - Big Boss Battle 2 (Crocomire, Kraid, Phantoon, Baby Metroid)
+; 23 - Tension/Hostile Incoming (before Kraid, Phantoon, and Baby Metroid. Played in between Croc segments)
+; 24 - Plant miniboss (Sporespawn and Botwoon)
+; 25 - Ceres Station (Unused)
+; 26 - Wrecked Ship Powered Off
+; 27 - Wrecked Ship Powered On
+; 28 - Theme of Super Metroid
+; 29 - Death cry
+; 30 - Ending
+; 41 - Crateria - Storm without music
+;
+; Extended tracks
+;
+; 31 - Kraid incoming (falls back to 23)
+; 32 - Kraid battle (falls back to 22)
+; 33 - Phantoon incoming (falls back to 23)
+; 34 - Phantoon battle (falls back to 22)
+; 35 - Draygon battle (falls back to 19)
+; 36 - Ridley battle (falls back to 19)
+; 37 - Baby incoming (falls back to 23)
+; 38 - The baby (falls back to 22)
+; 39 - Hyper beam (falls back 10)
+
+;;; Based on https://github.com/theonlydude/RandomMetroidSolver/blob/771edd125b2f46de1c3489c3be91994f9183a2e3/patches/common/src/supermetroid_msu1.asm
+;;; Extension based on https://github.com/Vivelin/SMZ3Randomizer/blob/8db3ec4cc13d89993e0b523ff26f29b9d2a983c0/alttp_sm_combo_randomizer_rom/src/sm/msu.asm
 ;;; assemble with asar v1.81 (https://github.com/RPGHacker/asar/releases/tag/v1.81)
 
 lorom


### PR DESCRIPTION
When people ask for the track indexes we can send this instead, as the Z3M3 wiki has a few incorrect (like Evacuation), and this includes the Crateria storm-only track.