### PR TITLE
Add Nothing item, use it for unreachable item spots

### DIFF
--- a/rust/src/game_data.rs
+++ b/rust/src/game_data.rs
@@ -95,6 +95,7 @@ pub enum Item {
     Morph,        // 19
     ReserveTank,  // 20
     WallJump,     // 21
+    Nothing,      // 22
 }
 
 impl Item {
@@ -105,6 +106,7 @@ impl Item {
             Item::PowerBomb,
             Item::ETank,
             Item::ReserveTank,
+            Item::Nothing,
         ]
         .contains(&self)
     }

--- a/rust/src/patch/map_tiles.rs
+++ b/rust/src/patch/map_tiles.rs
@@ -2289,7 +2289,7 @@ impl<'a> MapPatcher<'a> {
                 ItemMarkers::ThreeTiered => {
                     if item.is_unique() {
                         Interior::MajorItem
-                    } else if item != Item::Missile {
+                    } else if item != Item::Missile && item != Item::Nothing {
                         Interior::MediumItem
                     } else {
                         Interior::Item

--- a/rust/src/randomize.rs
+++ b/rust/src/randomize.rs
@@ -2972,7 +2972,7 @@ impl<'r> Randomizer<'r> {
         let mut idx = 0;
         for item_loc_state in &mut state.item_location_state {
             if item_loc_state.placed_item.is_none() {
-                item_loc_state.placed_item = Some(Item::Nothing);
+                item_loc_state.placed_item = Some(remaining_items[idx]);
                 idx += 1;
             }
         }
@@ -3655,7 +3655,7 @@ impl<'r> Randomizer<'r> {
             difficulty: self.difficulty_tiers[0].clone(),
             map: self.map.clone(),
             locked_doors: self.locked_doors.to_vec(),
-            item_placement: vec![Item::Missile; 100],  // Draw the non-existent items like Missile dots
+            item_placement: vec![Item::Nothing; 100],
             spoiler_log,
             seed,
             display_seed,

--- a/visualizer/script.js
+++ b/visualizer/script.js
@@ -512,6 +512,7 @@ fetch(`../spoiler.json`).then(c => c.json()).then(c => {
 		si.appendChild(item_info);
 	}
 	items: for (let v of c.all_items) {
+		if (v.item == "Nothing") { continue; }
 		let os = lookupOffset(v.location.room, v.location.node);
 		if (os) {
 			v.location.coords[0] += os[0];


### PR DESCRIPTION
This adds the Nothing item, implemented by using a pre-collected missile. Currently only used in spots never reached by logic.