### PR TITLE
Do not put Nothing in starting items

### DIFF
--- a/visualizer/script.js
+++ b/visualizer/script.js
@@ -397,6 +397,7 @@ fetch(`../spoiler.json`).then(c => c.json()).then(c => {
 				}
 			}
 			for (let i of ss.items) {
+				if (i == "Nothing") { continue; }
 				if (!ic.includes(item_plm[i])) {
 					si.appendChild(icon(item_plm[i]));
 				}


### PR DESCRIPTION
A fix that should hopefully prevent a spurious E-tank from showing up in the "starting items" section when Nothing items exist.