### PR TITLE
Clean up Part 2: Remove all unused code

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1510,7 +1510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2bf417de26ec0909f4e010f7b753d3c44c291f859b51a33e83eb5acb9bdfe78"
 dependencies = [
  "byteorder",
- "nom 5.1.2",
+ "nom 5.1.3",
 ]
 
 [[package]]
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
 dependencies = [
  "lexical-core",
  "memchr",

--- a/rust/src/bin/build-mosaic.rs
+++ b/rust/src/bin/build-mosaic.rs
@@ -28,10 +28,13 @@ struct Args {
 
 #[derive(Deserialize, Default, Clone, Debug)]
 struct TransitData {
-    name: String, // Intersecting room name (matching room geometry)
+    /// Intersecting room name (matching room geometry)
+    name: String,
     x: Vec<usize>,
-    top: String, // Transit tube theme above room (matching room name in TransitTube SMART project)
-    bottom: String, // Transit tube theme below room (matching room name in TransitTube SMART project)
+    /// Transit tube theme above room (matching room name in TransitTube SMART project)
+    top: String,
+    /// Transit tube theme below room (matching room name in TransitTube SMART project)
+    bottom: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -254,14 +257,7 @@ impl MosaicPatchBuilder {
         new_rom.enable_tracking();
         self.apply_cre_tileset(&mut new_rom)?;
         self.apply_sce_tilesets(&mut new_rom)?;
-        // self.apply_palettes(&mut new_rom)?;
 
-        // let patch = flips::BpsDeltaBuilder::new()
-        //     .source(&self.rom.data)
-        //     .target(&new_rom.data)
-        //     .build()?;
-        // let output_path = self.output_patches_dir.join("tilesets.bps");
-        // std::fs::write(&output_path, &patch)?;
         let modified_ranges = new_rom.get_modified_ranges();
         let mut encoder =
             BPSEncoder::new(&self.source_suffix_tree, &new_rom.data, &modified_ranges);
@@ -578,7 +574,6 @@ impl MosaicPatchBuilder {
         src_layer_2: &[u8],
     ) {
         let dst_size = dst_level_data[0] as usize + ((dst_level_data[1] as usize) << 8);
-        // println!("{} {} {} : {} {} {}", dst_screen_x, dst_screen_y, dst_width, src_screen_x, src_screen_y, src_width);
         for y in 0..16 {
             for x in 0..16 {
                 let src_x = src_screen_x * 16 + x;
@@ -624,7 +619,6 @@ impl MosaicPatchBuilder {
             let mut out = level_data[(2 + size * 3 / 2)..(2 + size * 5 / 2)].to_vec();
             if state_xml.layer1_2 == 0x91C9 {
                 // Scrolling sky BG: replicate first column of screens
-                // println!("Scrolling sky: {} {}", room_width, room_height);
                 for sy in 0..room_height {
                     for sx in 1..room_width {
                         for y in 0..16 {
@@ -691,7 +685,6 @@ impl MosaicPatchBuilder {
 
             // Set BG X scroll rate to 100%
             new_rom.write_u8(state_ptr + 12, 0x00 as isize)?;
-            // new_rom.write_u8(state_ptr + 13, 0x00 as isize)?;
 
             if state_xml.layer1_2 == 0x91C9 {
                 // Disable scrolling sky, in order to be able to draw the tube in Layer2.
@@ -743,7 +736,6 @@ impl MosaicPatchBuilder {
             let room_name = room_filename
                 .strip_suffix(".xml")
                 .context("Expecting room filename to end in .xml")?;
-            // println!("Room: {}", room_name);
             let room_str = std::fs::read_to_string(&room_path)
                 .with_context(|| format!("Unable to load room at {}", room_path.display()))?;
             let room: smart_xml::Room = serde_xml_rs::from_str(room_str.as_str())
@@ -1124,7 +1116,6 @@ impl MosaicPatchBuilder {
                             // Save the BPS patch to a file:
                             let output_filename =
                                 format!("{}-{:X}-Transit-{}-{}.bps", theme_name, room_ptr, x, -y);
-                            // info!("Writing {}", output_filename);
                             let output_path = self.output_patches_dir.join(output_filename);
                             std::fs::write(&output_path, &encoder.patch_bytes)?;
 

--- a/rust/src/bin/debug.rs
+++ b/rust/src/bin/debug.rs
@@ -206,21 +206,17 @@ fn run_scenario(
 fn main() -> Result<()> {
     let sm_json_data_path = Path::new("../sm-json-data");
     let room_geometry_path = Path::new("../room_geometry.json");
-    let palette_theme_path = Path::new("../palette_smart_exports");
     let escape_timings_path = Path::new("data/escape_timings.json");
     let start_locations_path = Path::new("data/start_locations.json");
     let hub_locations_path = Path::new("data/hub_locations.json");
-    let mosaic_path = Path::new("../Mosaic");
     let title_screen_path = Path::new("../TitleScreen/Images");
 
     let game_data = GameData::load(
         sm_json_data_path,
         room_geometry_path,
-        palette_theme_path,
         escape_timings_path,
         start_locations_path,
         hub_locations_path,
-        mosaic_path,
         title_screen_path,
     )?;
 

--- a/rust/src/bin/debug.rs
+++ b/rust/src/bin/debug.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use hashbrown::HashMap;
-// use hashbrown::HashSet;
 use maprando::{
     game_data::{Capacity, GameData, Item, Requirement},
     randomize::{
@@ -11,20 +10,6 @@ use maprando::{
     traverse::{apply_requirement, GlobalState, LocalState, LockedDoorData},
 };
 use std::path::Path;
-
-// fn strip_cross_room_reqs(req: &Requirement) -> Requirement {
-//     match req {
-//         Requirement::AdjacentRunway { .. } => Requirement::Never,
-//         Requirement::CanComeInCharged { .. } => Requirement::Never,
-//         Requirement::And(sub_reqs) => {
-//             Requirement::make_and(sub_reqs.iter().map(strip_cross_room_reqs).collect())
-//         }
-//         Requirement::Or(sub_reqs) => {
-//             Requirement::make_or(sub_reqs.iter().map(strip_cross_room_reqs).collect())
-//         }
-//         _ => req.clone(),
-//     }
-// }
 
 fn run_scenario(
     proficiency: f32,
@@ -161,10 +146,6 @@ fn run_scenario(
         debug_options: None,
     };
 
-    // println!(
-    //     "{:?}",
-    //     apply_requirement(&Requirement::PhantoonFight {  }, &global_state, local_state, false, &difficulty, &game_data)
-    // );
     let locked_door_data = LockedDoorData {
         locked_doors: vec![],
         locked_door_node_map: HashMap::new(),
@@ -182,17 +163,6 @@ fn run_scenario(
         game_data,
         &locked_door_data,
     );
-
-    // let new_local_state_opt = apply_requirement(
-    //         &Requirement::RidleyFight {
-    //             can_be_very_patient_tech_id: game_data.tech_isv.index_by_key["canBeVeryPatient"]
-    //         },
-    //         &global_state,
-    //         local_state,
-    //         false,
-    //         &difficulty,
-    //         game_data
-    // );
 
     let outcome = new_local_state_opt
         .map(|x| format!("{}", x.energy_used))
@@ -219,24 +189,6 @@ fn main() -> Result<()> {
         hub_locations_path,
         title_screen_path,
     )?;
-
-    // let proficiencies = vec![0.0, 0.3, 0.5, 0.7, 1.0];
-    // let missile_counts = vec![0, 5, 30, 60, 120];
-    // let super_counts = vec![0, 5, 30];
-    // let item_loadouts = vec![
-    //     vec![],
-    //     vec!["C"],
-    //     vec!["C", "I"],
-    //     vec!["C", "I", "W", "S"],
-    //     vec!["C", "P"],
-    //     vec!["C", "I", "W", "P"],
-    //     vec!["G"],
-    //     vec!["G", "C"],
-    //     vec!["G", "C", "I", "W", "P"],
-    //     vec!["V", "G"],
-    //     vec!["V", "G", "C"],
-    //     vec!["V", "G", "C", "I", "W", "P"],
-    // ];
 
     let proficiencies = vec![0.0, 0.3, 0.5, 0.7, 0.8, 0.825, 0.85, 0.9, 0.95, 1.0];
     let missile_counts = vec![20];

--- a/rust/src/bin/maprando-cli.rs
+++ b/rust/src/bin/maprando-cli.rs
@@ -50,81 +50,10 @@ struct Args {
 }
 
 fn get_randomization(args: &Args, game_data: &GameData) -> Result<Randomization> {
-    // let ignored_tech: Vec<String> = ["canWallIceClip", "canGrappleClip", "canUseSpeedEchoes"].iter().map(|x| x.to_string()).collect();
-    // let tech: Vec<String> = game_data.tech_isv.keys.iter().filter(|&x| !ignored_tech.contains(&x)).cloned().collect();
-    // let tech: Vec<String> = vec![
-    //     "canCrouchJump",
-    //     "canDownGrab",
-    //     "canHeatRun",
-    //     "canIBJ",
-    //     "canShinespark",
-    //     "canSuitlessMaridia",
-    //     "canWalljump"
-    //     //   "can3HighMidAirMorph",
-    //     // "canBlueSpaceJump",
-    //     // "canBombAboveIBJ",
-    //     // "canBombHorizontally",
-    //     // "canBombJumpWaterEscape",
-    //     // "canCeilingClip",
-    //     // "canCrabClimb",
-    //     // "canCrouchJump",
-    //     // "canCrumbleJump",
-    //     // "canCrumbleSpinJump",
-    //     // "canCrystalFlash",
-    //     // "canCrystalFlashForceStandup",
-    //     // "canDamageBoost",
-    //     // "canDownGrab",
-    //     // "canGateGlitch",
-    //     // "canGrappleJump",
-    //     // "canGravityJump",
-    //     // "canHBJ",
-    //     // "canHeatRun",
-    //     // "canHitbox",
-    //     // "canIBJ",
-    //     // "canIceZebetitesSkip",
-    //     // "canIframeSpikeJump",
-    //     // "canJumpIntoIBJ",
-    //     // "canLateralMidAirMorph",
-    //     // "canLavaGravityJump",
-    //     // "canMaridiaTubeClip",
-    //     // "canMetroidAvoid",
-    //     // "canMochtroidIceClimb",
-    //     // "canMochtroidIceClip",
-    //     // "canMockball",
-    //     // "canMoonfall",
-    //     // "canPreciseWalljump",
-    //     // "canQuickLowTideWalljumpWaterEscape",
-    //     // "canSandMochtroidIceClimb",
-    //     // "canShinespark",
-    //     // "canShotBlockOverload",
-    //     // "canSnailClimb",
-    //     // "canSnailClip",
-    //     // "canSpringBallJump",
-    //     // "canSpringBallJumpMidAir",
-    //     // "canStationaryLateralMidAirMorph",
-    //     // "canStationarySpinJump",
-    //     // "canSuitlessLavaDive",
-    //     // "canSuitlessMaridia",
-    //     // "canSuperReachAround",
-    //     // "canTrickyJump",
-    //     // "canTrickyUseFrozenEnemies",
-    //     // "canTunnelCrawl",
-    //     // "canTurnaroundAimCancel",
-    //     // "canTwoTileSqueeze",
-    //     // "canUnmorphBombBoost",
-    //     // "canUseEnemies",
-    //     // "canUseFrozenEnemies",
-    //     // "canWalljump",
-    //     // "canWrapAroundShot",
-    //     // "canXRayStandUp"
-    // ].iter().map(|x| x.to_string()).collect();
-    // let tech = vec![];
-
     let difficulty = DifficultyConfig {
         name: None,
         tech: game_data.tech_isv.keys.clone(),
         notable_strats: vec![],
-        // tech,
         shine_charge_tiles: 16.0,
         heated_shine_charge_tiles: 16.0,
         speed_ball_tiles: 24.0,
@@ -220,10 +149,6 @@ fn get_randomization(args: &Args, game_data: &GameData) -> Result<Randomization>
         item_progression_preset: Some("None".to_string()),
         quality_of_life_preset: Some("None".to_string()),
         debug_options: None,
-        // debug_options: Some(DebugOptions {
-        //     new_game_extra: true,
-        //     extended_spoiler: true,
-        // }),
     };
     let single_map: Option<Map>;
     let mut filenames: Vec<String> = Vec::new();
@@ -346,16 +271,6 @@ fn main() -> Result<()> {
 
     // Perform randomization (map selection & item placement):
     let randomization = get_randomization(&args, &game_data)?;
-
-    // Override locked doors:
-    //randomization.locked_doors.push(LockedDoor {
-    //    src_ptr_pair: (Some(0x19012), Some(0x18F52)),
-    //    dst_ptr_pair: (Some(0x18F52), Some(0x19012)),
-    //    door_type: maprando::randomize::DoorType::Yellow,
-    //    bidirectional: true });
-
-    // Override start location:
-    // randomization.start_location = game_data.start_locations.last().unwrap().clone();
 
     // Generate the patched ROM:
     let orig_rom = Rom::load(&args.input_rom)?;

--- a/rust/src/bin/maprando-cli.rs
+++ b/rust/src/bin/maprando-cli.rs
@@ -331,20 +331,16 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let sm_json_data_path = Path::new("../sm-json-data");
     let room_geometry_path = Path::new("../room_geometry.json");
-    let palette_theme_path = Path::new("../palette_smart_exports");
     let escape_timings_path = Path::new("data/escape_timings.json");
     let start_locations_path = Path::new("data/start_locations.json");
     let hub_locations_path = Path::new("data/hub_locations.json");
-    let mosaic_path = Path::new("../Mosaic");
     let title_screen_path = Path::new("../TitleScreen/Images");
     let game_data = GameData::load(
         sm_json_data_path,
         room_geometry_path,
-        palette_theme_path,
         escape_timings_path,
         start_locations_path,
         hub_locations_path,
-        mosaic_path,
         title_screen_path,
     )?;
 

--- a/rust/src/bin/maprando-test.rs
+++ b/rust/src/bin/maprando-test.rs
@@ -529,69 +529,6 @@ struct TestAppData {
     samus_sprites: Vec<String>,
 }
 
-// fn get_difficulty_tiers(app: &TestAppData, diff: &DifficultyConfig) -> Vec<DifficultyConfig> {
-//     let presets = &app.presets;
-//     let mut out: Vec<DifficultyConfig> = vec![];
-//     let tech_set: HashSet<String> = diff.tech.iter().cloned().collect();
-//     let strat_set: HashSet<String> = diff.notable_strats.iter().cloned().collect();
-
-//     out.push(diff.clone());
-//     out.last_mut().unwrap().tech.sort();
-//     out.last_mut().unwrap().notable_strats.sort();
-
-//     for p in presets.iter().rev() {
-//         let tech_vec: Vec<String> = p
-//             .tech
-//             .iter()
-//             .filter(|&x| tech_set.contains(x))
-//             .cloned()
-//             .collect();
-//         let strat_vec: Vec<String> = p
-//             .notable_strats
-//             .iter()
-//             .filter(|&x| strat_set.contains(x))
-//             .cloned()
-//             .collect();
-//         let new_diff = DifficultyConfig {
-//             name: Some(p.name.clone()),
-//             tech: tech_vec,
-//             notable_strats: strat_vec,
-//             shine_charge_tiles: f32::max(diff.shine_charge_tiles, p.shinespark_tiles as f32),
-//             heated_shine_charge_tiles: f32::max(
-//                 diff.heated_shine_charge_tiles,
-//                 p.heated_shinespark_tiles as f32,
-//             ),
-//             item_priorities: diff.item_priorities.clone(),
-//             starting_items: vec![],
-//             semi_filler_items: diff.semi_filler_items.clone(),
-//             filler_items: diff.filler_items.clone(),
-//             early_filler_items: diff.early_filler_items.clone(),
-//             resource_multiplier: f32::max(diff.resource_multiplier, p.resource_multiplier),
-//             gate_glitch_leniency: i32::max(
-//                 diff.gate_glitch_leniency,
-//                 p.gate_glitch_leniency as i32,
-//             ),
-//             door_stuck_leniency: i32::max(diff.door_stuck_leniency, p.door_stuck_leniency as i32),
-//             phantoon_proficiency: f32::min(diff.phantoon_proficiency, p.phantoon_proficiency),
-//             draygon_proficiency: f32::min(diff.draygon_proficiency, p.draygon_proficiency),
-//             ridley_proficiency: f32::min(diff.ridley_proficiency, p.ridley_proficiency),
-//             botwoon_proficiency: f32::min(diff.botwoon_proficiency, p.botwoon_proficiency),
-//             skill_assumptions_preset: diff.skill_assumptions_preset.clone(),
-//             item_progression_preset: diff.item_progression_preset.clone(),
-//             quality_of_life_preset: diff.quality_of_life_preset.clone(),
-//             debug_options: diff.debug_options.clone(),
-//             ..diff.clone()
-//         };
-//         if new_diff.tech == out.last().as_ref().unwrap().tech
-//             && new_diff.notable_strats == out.last().as_ref().unwrap().notable_strats
-//         {
-//             out.pop();
-//         }
-//         out.push(new_diff);
-//     }
-//     out
-// }
-
 fn get_randomization(app: &TestAppData, seed: u64) -> Result<(Randomization, String)> {
     let game_data = &app.game_data;
     let mut rng_seed = [0u8; 32];
@@ -634,11 +571,7 @@ fn get_randomization(app: &TestAppData, seed: u64) -> Result<(Randomization, Str
         "Generating seed using Skills {0}, Progression {1}, QoL {2}",
         skill_label, prog_label, qol_label
     );
-    // let difficulty_tiers = if diff.item_placement_style == ItemPlacementStyle::Forced {
-    //     get_difficulty_tiers(&app, &diff)
-    // } else {
-    //     vec![diff.clone()]
-    // };
+
     let difficulty_tiers = [diff.clone()]; // TODO needs to do the right thing for
                                            // ItemPlacementStyle::Forced
     let random_seed = (rng.next_u64() & 0xFFFFFFFF) as usize;
@@ -752,10 +685,6 @@ fn make_random_customization(app: &TestAppData) -> CustomizeSettings {
 }
 
 fn perform_test_cycle(app: &TestAppData, cycle_count: usize) -> Result<()> {
-    // let seed: u64 = app.rng_seed.unwrap_or_else(|| {
-    //     let mut rng = rand::rngs::StdRng::from_entropy();
-    //     rng.next_u64()
-    // });
     let seed: u64 = app.attempt_num.unwrap_or(cycle_count as u64);
 
     info!("Test cycle {cycle_count} Start: seed={}", seed);

--- a/rust/src/bin/maprando-test.rs
+++ b/rust/src/bin/maprando-test.rs
@@ -883,7 +883,6 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let sm_json_data_path = Path::new("../sm-json-data");
     let room_geometry_path = Path::new("../room_geometry.json");
-    let palette_theme_path = Path::new("../palette_smart_exports");
     let escape_timings_path = Path::new("data/escape_timings.json");
     let start_locations_path = Path::new("data/start_locations.json");
     let hub_locations_path = Path::new("data/hub_locations.json");
@@ -892,16 +891,13 @@ fn main() -> Result<()> {
     let tame_maps_path = Path::new("../maps/v113-tame");
     let wild_maps_path = Path::new("../maps/v110c-wild");
     let samus_sprites_path = Path::new("../MapRandoSprites/samus_sprites/manifest.json");
-    let mosaic_path = Path::new("../Mosaic");
     let title_screen_path = Path::new("../TitleScreen/Images");
     let game_data = GameData::load(
         sm_json_data_path,
         room_geometry_path,
-        palette_theme_path,
         escape_timings_path,
         start_locations_path,
         hub_locations_path,
-        mosaic_path,
         title_screen_path,
     )?;
 

--- a/rust/src/bin/maprando-web.rs
+++ b/rust/src/bin/maprando-web.rs
@@ -653,7 +653,6 @@ fn render_seed(
             .difficulty
             .semi_filler_items
             .iter()
-            // .filter(|&&x| x != Item::Nothing)
             .map(|x| format!("{:?}", x))
             .collect(),
         early_filler_items: seed_data
@@ -2112,11 +2111,9 @@ fn build_app_data() -> AppData {
     let hub_locations_path = Path::new("data/hub_locations.json");
     let etank_colors_path = Path::new("data/etank_colors.json");
     let vanilla_map_path = Path::new("../maps/vanilla");
-    // let tame_maps_path = Path::new("../maps/v93-tame");
     let tame_maps_path = Path::new("../maps/v113-tame");
     let wild_maps_path = Path::new("../maps/v110c-wild");
     let samus_sprites_path = Path::new("../MapRandoSprites/samus_sprites/manifest.json");
-    // let samus_spritesheet_layout_path = Path::new("data/samus_spritesheet_layout.json");
     let title_screen_path = Path::new("../TitleScreen/Images");
     let mosaic_themes = vec![
         ("OuterCrateria", "Outer Crateria"),
@@ -2146,7 +2143,6 @@ fn build_app_data() -> AppData {
     .unwrap();
 
     info!("Loading logic preset data");
-    // let samus_customizer = SamusSpriteCustomizer::new(samus_spritesheet_layout_path).unwrap();
     let tech_gif_listing = list_tech_gif_files();
     let notable_gif_listing = list_notable_gif_files();
     let presets: Vec<Preset> =
@@ -2194,7 +2190,6 @@ fn build_app_data() -> AppData {
         notable_gif_listing,
         logic_data,
         samus_sprite_categories,
-        // samus_customizer,
         debug: args.debug,
         version_info: VersionInfo {
             version: VERSION,

--- a/rust/src/bin/maprando-web.rs
+++ b/rust/src/bin/maprando-web.rs
@@ -475,7 +475,6 @@ struct SeedHeaderTemplate<'a> {
     save_animals: String,
     early_save: bool,
     area_assignment: String,
-    maps_revealed: String,
     ultra_low_qol: bool,
     preset_data: &'a [PresetData],
     enabled_tech: HashSet<String>,
@@ -695,7 +694,6 @@ fn render_seed(
         save_animals: seed_data.save_animals.clone(),
         early_save: seed_data.early_save,
         area_assignment: seed_data.area_assignment.clone(),
-        maps_revealed: seed_data.maps_revealed.clone(),
         ultra_low_qol: seed_data.ultra_low_qol,
         preset_data: &app_data.preset_data,
         enabled_tech,
@@ -2109,7 +2107,6 @@ fn build_app_data() -> AppData {
     let args = Args::parse();
     let sm_json_data_path = Path::new("../sm-json-data");
     let room_geometry_path = Path::new("../room_geometry.json");
-    let palette_theme_path = Path::new("../Mosaic/Projects");
     let escape_timings_path = Path::new("data/escape_timings.json");
     let start_locations_path = Path::new("data/start_locations.json");
     let hub_locations_path = Path::new("data/hub_locations.json");
@@ -2120,7 +2117,6 @@ fn build_app_data() -> AppData {
     let wild_maps_path = Path::new("../maps/v110c-wild");
     let samus_sprites_path = Path::new("../MapRandoSprites/samus_sprites/manifest.json");
     // let samus_spritesheet_layout_path = Path::new("data/samus_spritesheet_layout.json");
-    let mosaic_path = Path::new("../Mosaic");
     let title_screen_path = Path::new("../TitleScreen/Images");
     let mosaic_themes = vec![
         ("OuterCrateria", "Outer Crateria"),
@@ -2142,11 +2138,9 @@ fn build_app_data() -> AppData {
     let game_data = GameData::load(
         sm_json_data_path,
         room_geometry_path,
-        palette_theme_path,
         escape_timings_path,
         start_locations_path,
         hub_locations_path,
-        mosaic_path,
         title_screen_path,
     )
     .unwrap();

--- a/rust/src/customize.rs
+++ b/rust/src/customize.rs
@@ -346,7 +346,7 @@ pub fn customize_rom(
     match &settings.palette_theme {
         PaletteTheme::Vanilla => {}
         PaletteTheme::AreaThemed => {
-            apply_area_themed_palettes(rom, game_data)?;
+            apply_area_themed_palettes(rom)?;
         }
     }
 

--- a/rust/src/customize.rs
+++ b/rust/src/customize.rs
@@ -46,7 +46,6 @@ impl Allocator {
             if block.end_addr - block.current_addr >= size {
                 let addr = block.current_addr;
                 block.current_addr += size;
-                // println!("success: allocated {} bytes: ending at {:x}", size, pc2snes(block.current_addr));
                 return Ok(addr);
             }
         }
@@ -328,7 +327,6 @@ pub fn customize_rom(
 ) -> Result<()> {
     rom.resize(0x400000);
     let patch = ips::Patch::parse(seed_patch).unwrap();
-    // .with_context(|| format!("Unable to parse patch {}", patch_path.display()))?;
     for hunk in patch.hunks() {
         rom.write_n(hunk.offset(), hunk.payload())?;
     }
@@ -365,7 +363,6 @@ pub fn customize_rom(
     if let Some((r, g, b)) = settings.etank_color {
         let color = (r as isize) | ((g as isize) << 5) | ((b as isize) << 10);
         rom.write_u16(snes2pc(0x82FFFE), color)?; // Gameplay ETank color
-                                                  // rom.write_u16(snes2pc(0xB6F01A), color)?;
         rom.write_u16(snes2pc(0x8EE416), color)?; // Main menu
         rom.write_u16(snes2pc(0xA7CA7B), color)?; // During Phantoon power-on
     }
@@ -419,7 +416,6 @@ pub fn customize_rom(
             // Disable enemy shaking:
             rom.write_n(snes2pc(0xA09488), &[0xEA; 5])?; // 5 * NOP
             rom.write_n(snes2pc(0xA0948F), &[0xEA; 5])?; // 5 * NOP
-                                                         // rom.write_u8(snes2pc(0xA08712), 0x60)?;  // RTS
 
             // Disable enemy projectile shaking, by setting the displacements to zero:
             rom.write_n(snes2pc(0x86846B), &[0; 144])?;

--- a/rust/src/customize/retiling.rs
+++ b/rust/src/customize/retiling.rs
@@ -14,7 +14,6 @@ use super::TileTheme;
 const BPS_PATCH_PATH: &str = "../patches/mosaic";
 
 fn apply_bps_patch(rom: &mut Rom, orig_rom: &Rom, filename: &str) -> Result<()> {
-    // let patch_path = format!("{}-{:X}-{}.bps", theme_name, room_ptr, state_idx);
     let path = Path::new(BPS_PATCH_PATH).join(filename);
     let patch_bytes = std::fs::read(path).with_context(|| format!("Loading {}", filename))?;
     let patch = BPSPatch::new(patch_bytes)?;

--- a/rust/src/game_data.rs
+++ b/rust/src/game_data.rs
@@ -1,9 +1,8 @@
 pub mod smart_xml;
 
-use anyhow::{bail, ensure, Context, Result};
-// use log::info;
 use crate::patch::title::read_image;
 use crate::randomize::{BeamType, DoorType};
+use anyhow::{bail, ensure, Context, Result};
 use hashbrown::{HashMap, HashSet};
 use json::{self, JsonValue};
 use log::info;
@@ -159,7 +158,6 @@ pub enum Requirement {
     GravitylessAcidFrames(Capacity),
     MetroidFrames(Capacity),
     Damage(Capacity),
-    // Energy(i32),
     MissilesAvailable(Capacity),
     SupersAvailable(Capacity),
     PowerBombsAvailable(Capacity),
@@ -373,21 +371,13 @@ pub struct EscapeTimingDoor {
 #[derive(Deserialize, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum EscapeConditionRequirement {
-    // #[serde(rename = "enemies_cleared")]
     EnemiesCleared,
-    // #[serde(rename = "can_use_powerbombs")]
     CanUsePowerBombs,
-    // #[serde(rename = "can_moonfall")]
     CanMoonfall,
-    // #[serde(rename = "can_reverse_gate")]
     CanReverseGate,
-    // #[serde(rename = "can_acid_dive")]
     CanAcidDive,
-    // #[serde(rename = "can_off_camera_shot")]
     CanOffCameraShot,
-    // #[serde(rename = "can_kago")]
     CanKago,
-    // #[serde(rename = "can_hero_shot")]
     CanHeroShot,
 }
 
@@ -1180,9 +1170,6 @@ impl GameData {
                 bail!("Circular dependence in tech: {}", tech_name);
             }
         }
-        // if self.tech.contains_key(tech_name) {
-        //     return self.tech[tech_name].clone().unwrap();
-        // }
 
         // Temporarily insert a None value to act as a sentinel for detecting circular dependencies:
         self.tech
@@ -1778,8 +1765,7 @@ impl GameData {
                     .expect(&format!("invalid heatFrames in {}", req_json));
                 return Ok(Requirement::HeatFrames(frames as Capacity));
             } else if key == "gravitylessHeatFrames" {
-                // In Map Rando, Gravity doesn't affect heat frames, so this is treated the
-                // same as "heatFrames".
+                // In Map Rando, Gravity doesn't affect heat frames, so this is treated the same as "heatFrames".
                 let frames = value
                     .as_i32()
                     .expect(&format!("invalid gravitylessHeatFrames in {}", req_json));
@@ -1804,7 +1790,6 @@ impl GameData {
                     .as_i32()
                     .expect(&format!("invalid acidFrames in {}", req_json));
                 return Ok(Requirement::AcidFrames(frames as Capacity));
-                // return Ok(Requirement::Damage(3 * frames / 2));
             } else if key == "metroidFrames" {
                 let frames = value
                     .as_i32()
@@ -2019,11 +2004,6 @@ impl GameData {
                 return Ok(Requirement::make_or(reqs_or));
             } else if key == "doorUnlockedAtNode" {
                 let node_id = value.as_usize().unwrap();
-                // if ctx.unlocks_doors_json.is_some() {
-                //     info!("node_id={node_id}, unlocksDoors={}", ctx.unlocks_doors_json.unwrap());
-                // } else {
-                //     info!("node_id={node_id}, unlocksDoors=None");
-                // }
                 return self.get_unlocks_doors_req(node_id, ctx);
             } else if key == "itemNotCollectedAtNode" {
                 // TODO: implement this
@@ -2131,7 +2111,6 @@ impl GameData {
 
     fn override_morph_ball_room(&mut self, room_json: &mut JsonValue) {
         // Override the Careful Jump strat to get out from Morph Ball location:
-        //
         room_json["strats"]
             .members_mut()
             .find(|x| {
@@ -3984,36 +3963,6 @@ impl GameData {
         Ok(())
     }
 
-    // fn load_palette(&mut self, json_path: &Path) -> Result<()> {
-    //     let file = File::open(json_path)?;
-    //     let json_value: serde_json::Value = serde_json::from_reader(file)?;
-    //     for area_json in json_value.as_array().unwrap() {
-    //         let mut pal_map: HashMap<TilesetIdx, ThemedTileset> = HashMap::new();
-    //         for (tileset_idx_str, palette) in area_json.as_object().unwrap().iter() {
-    //             let tileset_idx: usize = tileset_idx_str.parse()?;
-    //             let mut pal = [[0u8; 3]; 128];
-    //             for (i, color) in palette.as_array().unwrap().iter().enumerate() {
-    //                 let color_arr = color.as_array().unwrap();
-    //                 let r = color_arr[0].as_i64().unwrap();
-    //                 let g = color_arr[1].as_i64().unwrap();
-    //                 let b = color_arr[2].as_i64().unwrap();
-    //                 pal[i][0] = r as u8;
-    //                 pal[i][1] = g as u8;
-    //                 pal[i][2] = b as u8;
-    //             }
-
-    //             // for i in 0..128 {
-    //             //     for j in 0..3 {
-    //             //         pal[i][j] = 0;
-    //             //     }
-    //             // }
-    //             pal_map.insert(tileset_idx, ThemedTileset { palette: pal });
-    //         }
-    //         self.tileset_palette_themes.push(pal_map);
-    //     }
-    //     Ok(())
-    // }
-
     fn extract_all_tech_dependencies(&mut self) -> Result<()> {
         let tech_vec = self.tech_isv.keys.clone();
         for tech in &tech_vec {
@@ -4306,33 +4255,6 @@ impl GameData {
             0x1AD000, // Tourian
         ];
         game_data.load_title_screens(title_screen_path)?;
-
-        // let debug_room_node_ids = vec![
-        //     (125, 3),
-        //     // (119, 3),
-        //     // (174, 1),
-        // ];
-        // for (vertex_id, key) in game_data.vertex_isv.keys.iter().enumerate() {
-        //     if debug_room_node_ids.contains(&(key.room_id, key.node_id)) {
-        //         println!("{}: {:?}", vertex_id, key);
-
-        //         for (_, link) in &game_data.base_links_data.links_by_src[vertex_id] {
-        //             println!(
-        //                 "{} -> {}: \"{}\" - {:?}",
-        //                 vertex_id, link.to_vertex_id, link.strat_name, link.requirement
-        //             );
-        //         }
-
-        //         for (_, link) in &game_data.base_links_data.links_by_dst[vertex_id] {
-        //             println!(
-        //                 "{} <- {}: \"{}\" - {:?}",
-        //                 vertex_id, link.to_vertex_id, link.strat_name, link.requirement
-        //             );
-        //         }
-
-        //         println!("")
-        //     }
-        // }
 
         Ok(game_data)
     }

--- a/rust/src/patch.rs
+++ b/rust/src/patch.rs
@@ -234,8 +234,6 @@ fn item_to_plm_type(item: Item, orig_plm_type: isize) -> isize {
     // Item container: 0 = none, 1 = chozo orb, 2 = shot block (scenery)
     let item_container = (orig_plm_type - 0xEED7) / 84;
 
-    // let plm_table: [[isize; 22]; 3] = [[0xF608; 22]; 3];
-
     let plm_table: [[isize; 23]; 3] = [
         [
             0xEED7, // Energy tank
@@ -439,7 +437,6 @@ impl<'a> Patcher<'a> {
             "shaktool",
             "fix_water_fx_bug",
             "seed_hash_display",
-            // "max_ammo_display",
             "max_ammo_display_fast",
             "stats",
             "credits",
@@ -459,12 +456,7 @@ impl<'a> Patcher<'a> {
         ];
 
         if self.randomization.difficulty.ultra_low_qol {
-            patches.extend([
-                "ultra_low_qol_vanilla_bugfixes",
-                // "ultra_low_qol_saveload",
-                // "ultra_low_qol_new_game",
-                // "ultra_low_qol_map_area",
-            ]);
+            patches.extend(["ultra_low_qol_vanilla_bugfixes"]);
         } else {
             patches.extend([
                 "vanilla_bugfixes",
@@ -489,7 +481,6 @@ impl<'a> Patcher<'a> {
             if options.new_game_extra {
                 new_game = "new_game_extra";
             }
-            // patches.push("items_test")
         }
         patches.push(new_game);
 
@@ -501,7 +492,6 @@ impl<'a> Patcher<'a> {
             || self.randomization.difficulty.stop_item_placement_early
         {
             patches.push("escape_items");
-            // patches.push("mother_brain_no_drain");
         }
 
         if self.randomization.difficulty.fast_elevators {
@@ -803,9 +793,6 @@ impl<'a> Patcher<'a> {
         }
 
         // Get x & y position of door (which we will turn gray during escape).
-        // let entrance_x = self.orig_rom.read_u8(other_door_pair.1.unwrap() + 4)? as u8;
-        // let entrance_y = self.orig_rom.read_u8(other_door_pair.1.unwrap() + 5)? as u8;
-        // println!("entrance: {} {}", entrance_x, entrance_y);
         let screen_x = self.orig_rom.read_u8(other_door_pair.1.unwrap() + 6)? as u8;
         let screen_y = self.orig_rom.read_u8(other_door_pair.1.unwrap() + 7)? as u8;
         let entrance_x = screen_x * 16 + 14;
@@ -914,7 +901,6 @@ impl<'a> Patcher<'a> {
         self.auto_reveal_arrows(&mut extra_door_asm)?;
         self.block_escape_return(&mut extra_door_asm)?;
         self.clamp_samus_position(&mut extra_door_asm)?;
-        // self.fix_tourian_blue_hopper(&mut extra_door_asm)?;
 
         let mut door_asm_free_space = 0xEE10; // in bank 0x8F
         let mut extra_door_asm_map: HashMap<DoorPtr, (AsmPtr, AsmPtr)> = HashMap::new();
@@ -1079,7 +1065,6 @@ impl<'a> Patcher<'a> {
             let new_base_x = self.map.rooms[i].0 as isize - area_map_min_x[new_area] + new_margin_x;
             let new_base_y = self.map.rooms[i].1 as isize - area_map_min_y[new_area] + new_margin_y;
             assert!(new_base_x >= 2);
-            // println!("map: {} {} {} {} {} {}", new_area, area_map_min_y[new_area], area_map_max_y[new_area], self.map.rooms[i].1, new_margin_y, new_base_y);
             assert!(new_base_y >= 0);
             self.rom.write_u8(room.rom_address + 2, new_base_x)?;
             self.rom.write_u8(room.rom_address + 3, new_base_y)?;
@@ -1130,8 +1115,6 @@ impl<'a> Patcher<'a> {
         }
 
         // Handle twin rooms:
-        // let aqueduct_room_idx = self.game_data.room_idx_by_name["Aqueduct"];
-        // room_index_area_hashmaps[4].insert(0x18, self.map.area[aqueduct_room_idx]); // Set Toilet to same map area as Aqueduct
         let pants_room_idx = self.game_data.room_idx_by_name["Pants Room"];
         room_index_area_hashmaps[4].insert(0x25, self.map.area[pants_room_idx]); // Set East Pants Room to same area as Pants Room
         let west_ocean_room_idx = self.game_data.room_idx_by_name["West Ocean"];
@@ -1246,7 +1229,6 @@ impl<'a> Patcher<'a> {
 
         let area_music: [[u16; 2]; NUM_AREAS] = [
             [
-                // (0x06, 0x05),   // Empty Crateria
                 0x050C, // Return to Crateria (ASM can replace with intro track or storm track)
                 0x0509, // Crateria Space Pirates (ASM can replace with zebes asleep track, with or without storm)
             ],
@@ -1310,11 +1292,6 @@ impl<'a> Patcher<'a> {
                     continue;
                 }
                 let new_song = area_music[area][subarea];
-                // if room.name == "Landing Site" {
-                //     // Set all Landing Site states to use the same track, the one that plays in vanilla before
-                //     // Power Bombs but after Zebes is awake:
-                //     new_song = 0x0606;
-                // }
                 self.rom.write_u16(state_ptr + 4, new_song as isize)?;
                 if room.name == "Pants Room" {
                     // Set music for East Pants Room:
@@ -1519,8 +1496,6 @@ impl<'a> Patcher<'a> {
         rng_seed[..8].copy_from_slice(&self.randomization.seed.to_le_bytes());
         let mut rng = rand::rngs::StdRng::from_seed(rng_seed);
 
-        // let image_path = Path::new("../gfx/title/Title3.png");
-        // let img = read_image(image_path)?;
         let mut img = Array3::<u8>::zeros((224, 256, 3));
         loop {
             let top_left_idx = rng.gen_range(0..self.game_data.title_screen_data.top_left.len());
@@ -2135,10 +2110,6 @@ impl<'a> Patcher<'a> {
             "down" => (door.x * 16 + 6, door.y * 16 + 14 - door.offset.unwrap_or(0)),
             _ => panic!("Unexpected door direction: {}", door.direction),
         };
-        // if let DoorType::Beam(_) = locked_door.door_type {
-        //     // Skip beam doors for the moment
-        //     return Ok(());
-        // }
         let plm_id = match (locked_door.door_type, door.direction.as_str()) {
             (DoorType::Yellow, "right") => 0xC85A,
             (DoorType::Yellow, "left") => 0xC860,
@@ -2293,7 +2264,6 @@ impl<'a> Patcher<'a> {
         }
         println!("extra setup ASM end: {:x}", next_addr);
         assert!(next_addr <= snes2pc(0xB8FFFF));
-        // assert!(next_addr <= snes2pc(0xB5FF00));
 
         Ok(())
     }
@@ -2367,7 +2337,6 @@ impl<'a> Patcher<'a> {
                 asm.extend([0x09, bitmask, 0x00]); // ORA #{bitmask}
                 asm.extend([0x8F, (addr & 0xFF) as u8, (addr >> 8) as u8, 0x70]);
                 // STA $70:{addr}
-                // println!("{:x} {} {}", room_ptr, x, y);
             }
         }
         self.extra_setup_asm
@@ -2491,8 +2460,10 @@ impl<'a> Patcher<'a> {
             let flip_x = 0x4000;
             let flip_y = 0x8000;
             let beam_pal = beam_palettes[beam_idx] << 10;
+
             // horizontal (left-side) door:
             let tilemap_ptr = free_space_addr + beam_idx * 2 * gfx_size;
+
             // 16x16 tile 0 (top)
             self.rom
                 .write_u16(tilemap_ptr + 0x00, 0x2340 | door_pal | flip_x)?; // door frame tile 0
@@ -2504,7 +2475,8 @@ impl<'a> Patcher<'a> {
                 tilemap_ptr + 0x06,
                 0x2000 | (beam_door_gfx_idx + 1) | door_pal,
             )?; // beam door tile 1
-                // 16x16 tile 1 (top middle):
+
+            // 16x16 tile 1 (top middle):
             self.rom
                 .write_u16(tilemap_ptr + 0x08, 0x2360 | door_pal | flip_x)?; // door frame tile 2
             self.rom.write_u16(
@@ -2517,7 +2489,8 @@ impl<'a> Patcher<'a> {
                 tilemap_ptr + 0x0E,
                 0x2000 | (beam_door_gfx_idx + 3) | beam_pal,
             )?; // beam door tile 3
-                // 16x16 tile 2 (bottom middle):
+
+            // 16x16 tile 2 (bottom middle):
             self.rom
                 .write_u16(tilemap_ptr + 0x10, 0x2370 | door_pal | flip_x | flip_y)?; // door frame tile 3 (vertical flip)
             self.rom.write_u16(
@@ -2530,7 +2503,8 @@ impl<'a> Patcher<'a> {
                 tilemap_ptr + 0x16,
                 0x2000 | (beam_door_gfx_idx + 5) | beam_pal,
             )?; // beam door tile 5
-                // 16x16 tile 3 (bottom):
+
+            // 16x16 tile 3 (bottom):
             self.rom
                 .write_u16(tilemap_ptr + 0x18, 0x2350 | door_pal | flip_x | flip_y)?; // door frame tile 1 (vertical flip)
             self.rom.write_u16(
@@ -2546,6 +2520,7 @@ impl<'a> Patcher<'a> {
 
             // vertical (top-side) door:
             let tilemap_ptr = free_space_addr + (beam_idx * 2 + 1) * gfx_size;
+
             // 16x16 tile 0 (left)
             self.rom
                 .write_u16(tilemap_ptr + 0x00, 0x2347 | door_pal | flip_x | flip_y)?; // door frame tile 0 (horizontal flip)
@@ -2557,7 +2532,8 @@ impl<'a> Patcher<'a> {
                 tilemap_ptr + 0x06,
                 0x2000 | (beam_door_gfx_idx + 1) | door_pal,
             )?; // beam door tile 1
-                // 16x16 tile 1 (left middle):
+
+            // 16x16 tile 1 (left middle):
             self.rom
                 .write_u16(tilemap_ptr + 0x08, 0x2345 | door_pal | flip_x | flip_y)?; // door frame tile 2 (horizontal flip)
             self.rom
@@ -2570,7 +2546,8 @@ impl<'a> Patcher<'a> {
                 tilemap_ptr + 0x0E,
                 0x2000 | (beam_door_gfx_idx + 3) | beam_pal,
             )?; // beam door tile 3
-                // 16x16 tile 2 (right middle):
+
+            // 16x16 tile 2 (right middle):
             self.rom
                 .write_u16(tilemap_ptr + 0x10, 0x2344 | door_pal | flip_y)?; // door frame tile 3
             self.rom
@@ -2583,7 +2560,8 @@ impl<'a> Patcher<'a> {
                 tilemap_ptr + 0x16,
                 0x2000 | (beam_door_gfx_idx + 5) | beam_pal,
             )?; // beam door tile 5
-                // 16x16 tile 3 (right):
+
+            // 16x16 tile 3 (right):
             self.rom
                 .write_u16(tilemap_ptr + 0x18, 0x2346 | door_pal | flip_y)?; // door frame tile 1
             self.rom
@@ -2674,8 +2652,9 @@ pub fn make_rom(
     // (removed here). Both of these have to be removed in order to successfully get rid of this wall.
     // (The change has to be applied to the original ROM before doors are reconnected based on the randomized map.)
     orig_rom.write_u8(snes2pc(0x83AA8F), 0x01)?; // Door direction = 0x01
-                                                 // Even though there is no door cap closing animation, we need to move the door cap X out of the way to the left,
-                                                 // otherwise corrupts the hazard marker PLM somehow:
+
+    // Even though there is no door cap closing animation, we need to move the door cap X out of the way to the left,
+    // otherwise corrupts the hazard marker PLM somehow:
     orig_rom.write_u8(snes2pc(0x83AA90), 0x1E)?; // Door cap X = 0x1E
 
     let mut rom = orig_rom.clone();

--- a/rust/src/patch.rs
+++ b/rust/src/patch.rs
@@ -51,7 +51,6 @@ pub struct Rom {
 
 impl Rom {
     pub fn new(data: Vec<u8>) -> Self {
-        let len = data.len();
         Rom {
             data,
             track_touched: false,

--- a/rust/src/patch/bps.rs
+++ b/rust/src/patch/bps.rs
@@ -7,10 +7,7 @@ const SOURCE_MATCH_THRESHOLD: usize = 4;
 
 #[derive(Debug)]
 enum BPSBlock {
-    Unchanged {
-        dst_start: usize,
-        length: usize,
-    },
+    Unchanged,
     SourceCopy {
         src_start: usize,
         dst_start: usize,
@@ -165,10 +162,7 @@ impl BPSDecoder {
         let length = (cmd >> 2) + 1;
         match action {
             0 => {
-                let block = BPSBlock::Unchanged {
-                    dst_start: self.output_pos,
-                    length,
-                };
+                let block = BPSBlock::Unchanged;
                 self.output_pos += length;
                 return Ok(block);
             }

--- a/rust/src/patch/decompress.rs
+++ b/rust/src/patch/decompress.rs
@@ -18,7 +18,6 @@ pub fn decompress(rom: &Rom, mut addr: usize) -> Result<Vec<u8>> {
             addr += 1;
             block_type = (byte >> 2) & 7;
         }
-        // println!("{addr}: len={0}, type={block_type}, size={size}", out.len());
 
         match block_type {
             0 => {

--- a/rust/src/patch/map_tiles.rs
+++ b/rust/src/patch/map_tiles.rs
@@ -58,8 +58,8 @@ enum Interior {
 enum LiquidType {
     None,
     Water,
-    Lava,
-    Acid,
+    _Lava,
+    _Acid,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -86,7 +86,6 @@ pub struct MapPatcher<'a> {
     basic_tile_map: HashMap<BasicTile, TilemapWord>,
     reverse_map: HashMap<TilemapWord, BasicTile>,
     tile_gfx_map: HashMap<TilemapWord, [[u8; 8]; 8]>,
-    edge_pixels_map: HashMap<Edge, Vec<usize>>,
     locked_door_state_indices: &'a [usize],
     area_data: Vec<Vec<(ItemIdx, TilemapOffset, TilemapWord, Interior)>>,
     transition_tile_coords: Vec<(AreaIdx, isize, isize)>,
@@ -171,7 +170,6 @@ impl<'a> MapPatcher<'a> {
             basic_tile_map: HashMap::new(),
             reverse_map: HashMap::new(),
             tile_gfx_map: HashMap::new(),
-            edge_pixels_map: pixels_map,
             locked_door_state_indices,
             area_data: vec![vec![]; 6],
             transition_tile_coords: vec![],
@@ -813,8 +811,8 @@ impl<'a> MapPatcher<'a> {
         let liquid_color = match (tile.liquid_type, tile.heated) {
             (LiquidType::None, _) => bg_color,
             (LiquidType::Water, _) => 0,
-            (LiquidType::Lava | LiquidType::Acid, false) => 2,
-            (LiquidType::Lava | LiquidType::Acid, true) => 1,
+            (LiquidType::_Lava | LiquidType::_Acid, false) => 2,
+            (LiquidType::_Lava | LiquidType::_Acid, true) => 1,
         };
         if tile.liquid_type != LiquidType::None {
             for y in tile.liquid_sublevel..8 {
@@ -2169,9 +2167,7 @@ impl<'a> MapPatcher<'a> {
                             let tile = self.get_basic_tile(basic_tile)?;
                             self.patch_room(room_name, vec![(x, y, tile)])?;
                         }
-                        Err(e) => {
-                            // println!("{} {} {:?}", x, y, e);
-                        }
+                        Err(_) => {}
                     }
                 }
             }

--- a/rust/src/patch/map_tiles.rs
+++ b/rust/src/patch/map_tiles.rs
@@ -515,16 +515,10 @@ impl<'a> MapPatcher<'a> {
 
     fn index_vanilla_tiles(&mut self) -> Result<()> {
         self.index_basic(0x10, W, W, E, P, V)?; // Elevator: walls on left & right; passage on bottom
-                                                // let tile = self.render_basic_tile(BasicTile { left: W, right: W, up: E, down: P, interior: V })?;
-                                                // self.write_tile_4bpp(0x10, tile)?;
 
         self.index_basic(0x4F, W, W, W, P, V)?; // Elevator: walls on left, right, & top; passage on bottom
-                                                // let tile = self.render_basic_tile(BasicTile { left: W, right: W, up: W, down: P, interior: V })?;
-                                                // self.write_tile_4bpp(0x4F, tile)?;
 
         self.index_basic(0x5F, P, P, P, W, V)?; // Elevator: passages on left, right, & top; wall on bottom
-                                                // let tile = self.render_basic_tile(BasicTile { left: P, right: P, up: P, down: W, interior: V })?;
-                                                // self.write_tile_4bpp(0x5F, tile)?;
 
         self.index_basic(0x1B, E, E, E, E, O)?; // Empty tile with no walls
         self.index_basic(0x20, W, W, W, W, O)?; // Empty tile with wall on all four sides
@@ -536,6 +530,7 @@ impl<'a> MapPatcher<'a> {
         self.index_basic(0x26, E, E, W, E, O)?; // Empty tile with wall on top
         self.index_basic(0x27, E, W, E, E, O)?; // Empty tile with wall on right
 
+        // Note: there's no item tile with walls on left and right.
         self.index_basic(0x76, E, E, W, E, I)?; // Item (dot) tile with a wall on top
         self.index_basic(0x77, W, E, E, E, I)?; // Item (dot) tile with a wall on left
         self.index_basic(0x5E, E, E, W, W, I)?; // Item (dot) tile with a wall on top and bottom
@@ -543,7 +538,6 @@ impl<'a> MapPatcher<'a> {
         self.index_basic(0x6F, W, W, W, W, I)?; // Item (dot) tile with a wall on all four sides
         self.index_basic(0x8E, W, E, W, E, I)?; // Item (dot) tile with a wall on top and left
         self.index_basic(0x8F, W, E, W, W, I)?; // Item (dot) tile with a wall on top, left, and bottom
-                                                // Note: there's no item tile with walls on left and right.
 
         self.index_basic(0x4D, E, E, E, E, Interior::Save)?; // Save station
         Ok(())
@@ -1024,16 +1018,6 @@ impl<'a> MapPatcher<'a> {
                         (7, 7),
                     ],
                 );
-                // update_tile(&mut data, 3, &vec![
-                //     (0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0),
-                //     (0, 1), (1, 1), (2, 1), (5, 1), (6, 1), (7, 1),
-                //     (0, 2), (1, 2), (6, 2), (7, 2),
-                //     (0, 3), (7, 3),
-                //     (0, 4), (7, 4),
-                //     (0, 5), (1, 5), (6, 5), (7, 5),
-                //     (0, 6), (1, 6), (2, 6), (5, 6), (6, 6), (7, 6),
-                //     (0, 7), (1, 7), (2, 7), (3, 7), (4, 7), (5, 7), (6, 7), (7, 7),
-                // ]);
             }
             Interior::AmmoRefill => {
                 update_tile(
@@ -1241,8 +1225,6 @@ impl<'a> MapPatcher<'a> {
         self.patch_room("Blue Brinstar Elevator Room", vec![(0, 3, ELEVATOR_TILE)])?;
         self.patch_room("Forgotten Highway Elevator", vec![(0, 3, ELEVATOR_TILE)])?;
         self.patch_room("Statues Room", vec![(0, 4, ELEVATOR_TILE)])?;
-        // We skip "Warehouse Entrance" since the room geometry (arbitrarily) did not include the arrow tile.
-        // self.patch_room("Warehouse Entrance", vec![(0, 3, ELEVATOR_TILE)])?;
 
         // Likewise, in bottom elevator rooms, replace up arrow tiles with elevator tiles:
         // Oddly, in Main Shaft there wasn't an arrow here in the vanilla game. But we left a spot in the room geometry as if there were.
@@ -1253,9 +1235,6 @@ impl<'a> MapPatcher<'a> {
         // rooms in the room geometry (an inconsistency which doesn't really matter because its only observable effect is in the
         // final length of the elevator on the map, which already has variations across rooms). We skip Lower Norfair Elevator
         // and Main Hall because these have no arrows on the vanilla map (since these don't cross regions in vanilla).
-
-        // // Patch map tile in Aqueduct to replace Botwoon Hallway with tube/elevator tile
-        // self.patch_room("Aqueduct", vec![(2, 3, ELEVATOR_TILE)])?;
 
         Ok(())
     }
@@ -1874,7 +1853,6 @@ impl<'a> MapPatcher<'a> {
 
         // Wrecked Ship:
         self.patch_room_basic("Basement", vec![(3, 0, E, P, W, W, O)])?;
-        // self.patch_room_basic("Sponge Bath", vec![(1, 0, P, D, W, W, O)])?;
         self.patch_room_basic("Electric Death Room", vec![(0, 1, W, D, P, E, O)])?;
         self.patch_room_basic("Wrecked Ship East Super Room", vec![(3, 0, P, W, W, W, I)])?;
         self.patch_room_basic(
@@ -2180,48 +2158,13 @@ impl<'a> MapPatcher<'a> {
         self.indicate_liquid_room("The Moat", LiquidType::Water, 1, 0)?;
         self.indicate_liquid_room("West Ocean", LiquidType::Water, 5, 0)?;
         self.indicate_liquid_room("East Ocean", LiquidType::Water, 5, 0)?;
-        // self.indicate_liquid_room("Bowling Alley Path", LiquidType::Water, 0, 5)?;
-        // self.indicate_liquid_room("Crab Maze", LiquidType::Water, 1, 5)?;
         self.indicate_liquid_room("Statues Room", LiquidType::Water, 1, 0)?;
-        // self.indicate_liquid_room("Gauntlet Entrance", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Gauntlet Energy Tank Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Crateria Power Bomb Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Crateria Super Room", LiquidType::Acid, 7, 5)?;
-
-        // Brinstar:
-        // self.indicate_liquid_room("Blue Brinstar Boulder Room", LiquidType::Water, 0, 5)?;
-        // self.indicate_liquid_room("Waterway Energy Tank Room", LiquidType::Water, 0, 5)?;
-        // self.indicate_liquid_room("Bat Room", LiquidType::Water, 0, 5)?;
-        // self.indicate_liquid_room("Below Spazer", LiquidType::Water, 1, 5)?;
 
         // Norfair:
-        // self.indicate_liquid_room("Ice Beam Tutorial Room", LiquidType::Lava, 0, 5)?;
-        // self.indicate_liquid_room("Ice Beam Acid Room", LiquidType::Lava, 0, 5)?;
-        // self.indicate_liquid_room("Crocomire Escape", LiquidType::Lava, 1, 5)?;
-        // self.indicate_liquid_room("Crocomire's Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Post Crocomire Missile Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Post Crocomire Jump Room", LiquidType::Acid, 2, 5)?;
         self.indicate_liquid_room("Grapple Tutorial Room 1", LiquidType::Water, 1, 0)?;
         self.indicate_liquid_room("Grapple Tutorial Room 3", LiquidType::Water, 1, 0)?;
-        // self.indicate_liquid_room("Acid Snakes Tunnel", LiquidType::Lava, 0, 5)?;
-        // self.indicate_liquid_room("Spiky Acid Snakes Tunnel", LiquidType::Lava, 0, 5)?;
-        // self.indicate_liquid_room("Magdollite Tunnel", LiquidType::Lava, 0, 5)?;
-        // self.indicate_liquid_room("Cathedral", LiquidType::Lava, 1, 5)?;
-        // self.indicate_liquid_room("Rising Tide", LiquidType::Lava, 0, 5)?;
-        // self.indicate_liquid_room("Bat Cave", LiquidType::Lava, 1, 5)?;
-        // self.indicate_liquid_room("Volcano Room", LiquidType::Lava, 2, 5)?;
-        // self.indicate_liquid_room("Spiky Platforms Tunnel", LiquidType::Lava, 0, 5)?;
-        // self.indicate_liquid_room("Lava Dive Room", LiquidType::Lava, 1, 0)?;
-        // self.indicate_liquid_room("Main Hall", LiquidType::Acid, 2, 5)?;
-        // self.indicate_liquid_room("Acid Statue Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Fast Ripper Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Pillar Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Amphitheatre", LiquidType::Acid, 1, 0)?;
 
         // Wrecked Ship:
-        // self.indicate_liquid_room("Sponge Bath", LiquidType::Water, 0, 5)?;
-        // self.indicate_liquid_room("Spiky Death Room", LiquidType::Water, 0, 5)?;
-        // self.indicate_liquid_room("Electric Death Room", LiquidType::Water, 2, 5)?;
         self.indicate_liquid_room("Wrecked Ship Energy Tank Room", LiquidType::Water, 1, 0)?;
 
         // Maridia:
@@ -2234,11 +2177,8 @@ impl<'a> MapPatcher<'a> {
         self.indicate_liquid_room("Red Fish Room", LiquidType::Water, 1, 0)?;
         self.indicate_liquid_room("Crab Shaft", LiquidType::Water, 0, 0)?;
         self.indicate_liquid_room("Pseudo Plasma Spark Room", LiquidType::Water, 2, 0)?;
-        // self.indicate_liquid_room("Northwest Maridia Bug Room", LiquidType::Water, 1, 5)?;
         self.indicate_liquid_room("Watering Hole", LiquidType::Water, 2, 0)?;
         self.indicate_liquid_room("Plasma Spark Room", LiquidType::Water, 4, 0)?;
-        // self.indicate_liquid_room("Maridia Elevator Room", LiquidType::Water, 5, 5)?;
-        // self.indicate_liquid_room("Thread The Needle Room", LiquidType::Water, 0, 5)?;
         self.indicate_liquid_room("Bug Sand Hole", LiquidType::Water, 0, 5)?;
         self.indicate_liquid_room("Plasma Beach Quicksand Room", LiquidType::Water, 0, 0)?;
         self.indicate_liquid_room("Butterfly Room", LiquidType::Water, 0, 0)?;
@@ -2269,15 +2209,7 @@ impl<'a> MapPatcher<'a> {
         self.indicate_liquid_room("East Aqueduct Quicksand Room", LiquidType::Water, 0, 0)?;
         self.indicate_liquid_room("Oasis", LiquidType::Water, 0, 0)?;
         self.indicate_liquid_room("Pants Room", LiquidType::Water, 2, 0)?;
-        // self.indicate_liquid_room("Shaktool Room", LiquidType::Water, 0, 5)?;
         self.indicate_liquid_room("Spring Ball Room", LiquidType::Water, 1, 0)?;
-
-        // Tourian:
-        // self.indicate_liquid_room("Tourian First Room", LiquidType::Acid, 3, 5)?;
-        // self.indicate_liquid_room("Metroid Room 1", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Metroid Room 3", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Mother Brain Room", LiquidType::Acid, 0, 5)?;
-        // self.indicate_liquid_room("Tourian Escape Room 4", LiquidType::Acid, 3, 5)?;
 
         Ok(())
     }
@@ -2840,21 +2772,6 @@ impl<'a> MapPatcher<'a> {
         Ok(())
     }
 
-    fn fix_etank_color(&mut self) -> Result<()> {
-        // let etank_tile: [[u8; 8]; 8] = [
-        //     [0, 0, 0, 0, 0, 0, 0, 0],
-        //     [0, 2, 2, 2, 2, 2, 2, 0],
-        //     [0, 2, 3, 3, 3, 3, 3, 0],
-        //     [0, 2, 3, 3, 3, 3, 3, 0],
-        //     [0, 2, 3, 3, 3, 3, 3, 0],
-        //     [0, 2, 3, 3, 3, 3, 3, 0],
-        //     [0, 0, 0, 0, 0, 0, 0, 0],
-        //     [0, 0, 0, 0, 0, 0, 0, 0],
-        // ];
-        // self.write_tile_2bpp(0x31, etank_tile, false)?;
-        Ok(())
-    }
-
     fn fix_message_boxes(&mut self) -> Result<()> {
         // Fix message boxes GFX: use white letters (color 2) instead of dark gray (color 1)
         for idx in 0xC0..0x100 {
@@ -3037,7 +2954,8 @@ impl<'a> MapPatcher<'a> {
             TILE_GFX_ADDR_2BPP as isize + kraid_map_area.unwrap() * 0x10000,
         )?;
         self.rom.write_u16(snes2pc(0x8FB81C), 0x0C00)?; // avoid overwriting hazard tiles with (unneeded) message box tiles
-                                                        // Kraid dead:
+
+        // Kraid dead:
         self.rom.write_u24(
             snes2pc(0x8FB842),
             TILE_GFX_ADDR_2BPP as isize + kraid_map_area.unwrap() * 0x10000,
@@ -3159,6 +3077,7 @@ impl<'a> MapPatcher<'a> {
         let flip_door_frame2_idx = 0x366;
         let flip_door_frame3_idx = 0x365;
         let flip_door_frame4_idx = 0x364;
+
         // Top fourth of door going right:
         self.rom.write_u16(base_addr, hazard_tile1_idx | 0x2000)?; // top-left quarter (palette 0)
         self.rom
@@ -3167,7 +3086,8 @@ impl<'a> MapPatcher<'a> {
             .write_u16(base_addr + 4, hazard_tile2_idx | 0x2000)?; // top-left quarter (palette 0)
         self.rom
             .write_u16(base_addr + 6, door_frame2_idx | 0x2400)?; // top-right quarter (palette 1)
-                                                                  // Second-from top fourth of door going right:
+
+        // Second-from top fourth of door going right:
         self.rom
             .write_u16(base_addr + 8, hazard_tile3_idx | 0x2000)?; // top-left quarter (palette 0)
         self.rom
@@ -3176,7 +3096,8 @@ impl<'a> MapPatcher<'a> {
             .write_u16(base_addr + 12, hazard_tile4_idx | 0x2000)?; // top-left quarter (palette 0)
         self.rom
             .write_u16(base_addr + 14, door_frame4_idx | 0x2400)?; // top-right quarter (palette 1)
-                                                                   // Left fourth of door going down:
+
+        // Left fourth of door going down:
         self.rom
             .write_u16(base_addr + 16, flip_hazard_tile1_idx | 0x2000)?; // top-left quarter (palette 0)
         self.rom
@@ -3185,7 +3106,8 @@ impl<'a> MapPatcher<'a> {
             .write_u16(base_addr + 20, flip_door_frame1_idx | 0x6400)?; // top-right quarter (palette 1, X flip)
         self.rom
             .write_u16(base_addr + 22, flip_door_frame2_idx | 0x6400)?; // top-right quarter (palette 1, X flip)
-                                                                        // Second-from left fourth of door going down:
+
+        // Second-from left fourth of door going down:
         self.rom
             .write_u16(base_addr + 24, flip_hazard_tile3_idx | 0x2000)?; // top-left quarter (palette 0)
         self.rom
@@ -3204,7 +3126,6 @@ impl<'a> MapPatcher<'a> {
         self.fix_message_boxes()?;
         self.fix_hud_black()?;
         self.darken_hud_grid()?;
-        self.fix_etank_color()?;
         self.index_vanilla_tiles()?;
         self.fix_elevators()?;
         self.fix_item_dots()?;
@@ -3235,7 +3156,7 @@ impl<'a> MapPatcher<'a> {
         self.fix_fx_palettes()?;
         self.fix_kraid()?;
         self.fix_item_colors()?;
-        // info!("Free tiles: {} (out of {})", self.free_tiles.len() - self.next_free_tile_idx, self.free_tiles.len());
+
         Ok(())
     }
 }

--- a/rust/src/patch/suffix_tree.rs
+++ b/rust/src/patch/suffix_tree.rs
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn test_random() {
         let mut rng = rand::rngs::StdRng::from_seed([0u8; 32]);
-        for i in 0..100 {
+        for _ in 0..100 {
             let mut data = vec![];
             let length = 1000;
             for _ in 0..length {

--- a/rust/src/patch/suffix_tree.rs
+++ b/rust/src/patch/suffix_tree.rs
@@ -75,9 +75,7 @@ impl SuffixTree {
             },
         };
         for &b in data {
-            // println!("data: {:?}", tree.data);
             tree.push_byte(b);
-            // println!("end: {:?}", tree);
         }
         tree
     }
@@ -168,8 +166,6 @@ impl SuffixTree {
         // For i less than the cut position, this is already taken care of automatically, since in such cases
         // data[i..] is represented by a leaf, which has an implicit end position (DATA_END).
         loop {
-            // println!("tree: {:?}", self);
-
             let cut = &self.cut;
             let num_nodes = self.nodes.len();
             let node = &mut self.nodes[cut.node_id as usize];

--- a/rust/src/patch/title.rs
+++ b/rust/src/patch/title.rs
@@ -231,7 +231,6 @@ impl<'a> TitlePatcher<'a> {
                     if intensity > 3 {
                         intensity = 3;
                     }
-                    // intensity = 0;
                 } else if color_plane_mask == 0xC0 {
                     // Effect applied to only blue and green color planes (used for additive mode, at bottom of screen)
                     // Apply the effect to all 3 color planes, producing a grayscale gradient instead of cyan.
@@ -288,7 +287,6 @@ impl<'a> TitlePatcher<'a> {
                 &decompressed[(i * 32)..(i * 32 + 32)].try_into()?,
             ));
         }
-        // println!("{:?}", tiles[1]);
         Ok(tiles)
     }
 
@@ -326,7 +324,6 @@ impl<'a> TitlePatcher<'a> {
             });
             pc_addr += 5;
         }
-        // println!("{:?}", out);
         Ok(out)
     }
 

--- a/rust/src/patch/title.rs
+++ b/rust/src/patch/title.rs
@@ -39,13 +39,6 @@ fn rgb_to_u16(rgb: (u8, u8, u8)) -> u16 {
     (r as u16) | (g as u16) << 5 | (b as u16) << 10
 }
 
-fn u16_to_rgb(color: u16) -> (u8, u8, u8) {
-    let r = color & 0x1F;
-    let g = (color >> 5) & 0x1F;
-    let b = (color >> 10) & 0x1F;
-    (r as u8, g as u8, b as u8)
-}
-
 struct Graphics {
     palette: Vec<(u8, u8, u8)>,
     tiles: Vec<[[u8; 8]; 8]>, // indices into `palette`

--- a/rust/src/randomize.rs
+++ b/rust/src/randomize.rs
@@ -225,7 +225,6 @@ pub struct DifficultyConfig {
     pub name: Option<String>,
     pub tech: Vec<String>,
     pub notable_strats: Vec<String>,
-    // pub notable_strats: Vec<String>,
     pub shine_charge_tiles: f32,
     pub heated_shine_charge_tiles: f32,
     pub shinecharge_leniency_frames: Capacity,
@@ -507,7 +506,6 @@ impl<'a> Preprocessor<'a> {
                 game_data.door_ptr_pair_map[&(src_exit_ptr, src_entrance_ptr)];
             let (dst_room_id, dst_node_id) =
                 game_data.door_ptr_pair_map[&(dst_exit_ptr, dst_entrance_ptr)];
-            // println!("({}, {}) <-> ({}, {})", src_room_id, src_node_id, dst_room_id, dst_node_id);
             door_map.insert((src_room_id, src_node_id), (dst_room_id, dst_node_id));
             door_map.insert((dst_room_id, dst_node_id), (src_room_id, src_node_id));
 
@@ -2557,36 +2555,6 @@ fn ensure_enough_tanks(initial_items_remaining: &mut [usize], difficulty: &Diffi
             initial_items_remaining[Item::ETank as usize] += 1;
         }
     }
-    // // let mut global = GlobalState {
-    //     tech: vec![true; game_data.tech_isv.keys.len()],
-    //     notable_strats: vec![true; game_data.notable_strat_isv.keys.len()],
-    //     items: vec![true; game_data.item_isv.keys.len()],
-    //     flags: vec![true; game_data.flag_isv.keys.len()],
-    //     max_energy: 99,
-    //     max_reserves: 0,
-    //     max_missiles: 0,
-    //     max_supers: 0,
-    //     max_power_bombs: 0,
-    //     weapon_mask: 0,
-    //     shine_charge_tiles: 32.0,
-    //     heated_shine_charge_tiles: 32.0,
-    // };
-    // for (item_idx, &cnt) in initial_items_remaining.iter().enumerate() {
-    //     for _ in 0..cnt {
-    //         global.collect(Item::try_from(item_idx).unwrap(), game_data);
-    //     }
-    // }
-    // let local = LocalState::new();
-    // while initial_items_remaining[Item::ETank as usize] <= 14 {
-    //     let result = apply_ridley_requirement(&global, local, difficulty.ridley_proficiency, 0);
-    //     if result.is_some() {
-    //         return;
-    //     }
-    //     println!("Adding extra tank to ensure Ridley is beatable");
-    //     initial_items_remaining[Item::ETank as usize] += 1;
-    //     global.collect(Item::ETank, game_data);
-    // }
-    // panic!("Not able to ensure Ridley beatable")
 }
 
 impl<'r> Randomizer<'r> {
@@ -2710,7 +2678,6 @@ impl<'r> Randomizer<'r> {
 
     fn update_reachability(&self, state: &mut RandomizationState) {
         let num_vertices = self.game_data.vertex_isv.keys.len();
-        // let start_vertex_id = self.game_data.vertex_isv.index_by_key[&(8, 5, 0)]; // Landing site
         let start_vertex_id = self.game_data.vertex_isv.index_by_key[&VertexKey {
             room_id: state.hub_location.room_id,
             node_id: state.hub_location.node_id,
@@ -2853,7 +2820,6 @@ impl<'r> Randomizer<'r> {
             .collect();
         let num_key_items_remaining = filtered_item_precedence.len();
         let num_items_remaining: usize = state.items_remaining.iter().sum();
-        // println!("num_items_to_place={num_items_to_place}, num_items_remaining={num_items_remaining}");
         let mut num_key_items_to_place = match self.difficulty_tiers[0].progression_rate {
             ProgressionRate::Slow => 1,
             ProgressionRate::Uniform => usize::max(
@@ -2887,7 +2853,6 @@ impl<'r> Randomizer<'r> {
 
         let num_filler_items_to_place = num_items_to_place - num_key_items_to_place;
 
-        // println!("{} {}: {} {}", num_bireachable, num_oneway_reachable, num_key_items_remaining, num_filler_items_to_place);
         (num_key_items_to_place, num_filler_items_to_place)
     }
 
@@ -3028,8 +2993,6 @@ impl<'r> Randomizer<'r> {
                 return None;
             }
 
-            // info!("remaining_items={}", remaining_items.len());
-
             // If we will be placing `k` key items, we let the first `k - 1` items to place remain fixed based on the
             // item precedence order, while we vary the last key item across attempts (to try to find some choice that
             // will expand the set of bireachable item locations).
@@ -3077,7 +3040,6 @@ impl<'r> Randomizer<'r> {
         // lower difficulty tiers. This function returns an index into `bireachable_locations`, identifying
         // a location with the hardest possible difficulty to reach.
         let num_vertices = self.game_data.vertex_isv.keys.len();
-        // let start_vertex_id = self.game_data.vertex_isv.index_by_key[&(8, 5, 0)]; // Landing site
         let start_vertex_id = self.game_data.vertex_isv.index_by_key[&VertexKey {
             room_id: state.hub_location.room_id,
             node_id: state.hub_location.node_id,
@@ -3085,32 +3047,12 @@ impl<'r> Randomizer<'r> {
             actions: vec![],
         }];
 
-        // for &v in &state.key_visited_vertices {
-        //     println!("key visited: {:?}", self.game_data.vertex_isv.keys[v]);
-        // }
-        // println!("items: {:?}", state.global_state.items);
-
-        // println!("global_state: {:?}", state.global_state);
-        // print!("Flags: ");
-        // for (i, flag) in self.game_data.flag_isv.keys.iter().enumerate() {
-        //     if state.global_state.flags[i] {
-        //         print!("{} ", flag);
-        //     }
-        // }
-        // println!("");
-
         for tier in 1..self.difficulty_tiers.len() {
             let difficulty = &self.difficulty_tiers[tier];
             let mut tmp_global = state.global_state.clone();
             tmp_global.tech = get_tech_vec(&self.game_data, difficulty);
             tmp_global.notable_strats = get_strat_vec(&self.game_data, difficulty);
-            // print!("tier:{} tech:", tier);
-            // for (i, tech) in self.game_data.tech_isv.keys.iter().enumerate() {
-            //     if tmp_global.tech[i] {
-            //         print!("{} ", tech);
-            //     }
-            // }
-            // println!("");
+
             let traverse_result = traverse(
                 &self.base_links_data,
                 &self.seed_links_data,
@@ -3160,7 +3102,6 @@ impl<'r> Randomizer<'r> {
         let skip_hard_placement = !self.difficulty_tiers[0].stop_item_placement_early
             && num_items_remaining < num_items_to_place + KEY_ITEM_FINISH_THRESHOLD;
 
-        // println!("[attempt {attempt_num_rando}] # bireachable = {}", bireachable_locations.len());
         let mut new_bireachable_locations: Vec<ItemLocationId> = bireachable_locations.to_vec();
         if self.difficulty_tiers.len() > 1 && !skip_hard_placement {
             let traverse_result = match state.previous_debug_data.as_ref() {
@@ -3286,8 +3227,6 @@ impl<'r> Randomizer<'r> {
             new_state.global_state.collect(item, self.game_data);
         }
 
-        // info!("Trying placing {:?}", key_items);
-
         self.update_reachability(new_state);
         let num_bireachable = new_state
             .item_location_state
@@ -3365,7 +3304,6 @@ impl<'r> Randomizer<'r> {
             previous_debug_data: None,
             key_visited_vertices: HashSet::new(),
         };
-        // println!("filler items len={selected_filler_items_len}");
         for &item in &selected_filler_items {
             // We check if items_remaining is positive, only because with "Stop item placement early" there
             // could be extra (unplanned) Nothing items placed.
@@ -3373,11 +3311,8 @@ impl<'r> Randomizer<'r> {
                 new_state_filler.items_remaining[item as usize] -= 1;
             }
         }
-        // let num_items_remaining: usize = new_state_filler.items_remaining.iter().sum();
-        // println!("post filler num_items_remaining={num_items_remaining}");
 
         let mut attempt_num = 0;
-        // info!("num_key_items_to_select={num_key_items_to_select}, num_filler_items_to_select={num_filler_items_to_select}");
         let mut selected_key_items = self
             .select_key_items(&new_state_filler, num_key_items_to_select, attempt_num)
             .unwrap();
@@ -3735,10 +3670,6 @@ impl<'r> Randomizer<'r> {
             .enumerate()
             .zip(self.game_data.room_geometry.iter())
             .map(|((room_idx, c), g)| {
-                // let room = self.game_data.room_json_map[&room]["name"]
-                //     .as_str()
-                //     .unwrap()
-                //     .to_string();
                 let room = g.name.clone();
                 let short_name = strip_name(&room);
                 let map = if room_idx == self.game_data.toilet_room_idx {
@@ -3788,11 +3719,6 @@ impl<'r> Randomizer<'r> {
             all_rooms: spoiler_all_rooms,
         };
 
-        // // Messing around with starting location. TODO: remove this
-        // let start_locations: Vec<StartLocation> =
-        //     serde_json::from_str(&std::fs::read_to_string(&"data/start_locations.json").unwrap()).unwrap();
-        // let loc = start_locations.last().unwrap();
-
         Ok(Randomization {
             difficulty: self.difficulty_tiers[0].clone(),
             map: self.map.clone(),
@@ -3803,7 +3729,6 @@ impl<'r> Randomizer<'r> {
             seed,
             display_seed,
             seed_name: self.get_seed_name(seed),
-            // start_location: loc.clone(),
             start_location: state.start_location.clone(),
             starting_items: self.difficulty_tiers[0].starting_items.clone(),
         })
@@ -4259,12 +4184,6 @@ impl<'r> Randomizer<'r> {
                 // No further progress was made on the last step. So we are done with this attempt: either we have
                 // succeeded or we have failed.
 
-                // // TODO: get rid of this
-                // if self.difficulty_tiers[0].debug_options.is_some() {
-                //     // If debugging, accept failed seed generation.
-                //     break;
-                // }
-
                 if !self.is_game_beatable(&state) {
                     bail!("[attempt {attempt_num_rando}] Attempt failed: Game not beatable");
                 }
@@ -4547,8 +4466,6 @@ impl<'a> Randomizer<'a> {
                     obstacle_mask: to_obstacles_mask,
                     ..
                 } = self.game_data.vertex_isv.keys[link.to_vertex_id];
-                // info!("local: {:?}", local_state);
-                // info!("{:?}", link);
                 let door_coords = self
                     .game_data
                     .node_coords
@@ -4561,14 +4478,11 @@ impl<'a> Randomizer<'a> {
                     )
                 });
 
-                // let debug_info = format!("{:?}", vertex_key);
-
                 let spoiler_entry = SpoilerRouteEntry {
                     area: to_vertex_info.area_name,
                     short_room: strip_name(&to_vertex_info.room_name),
                     room: to_vertex_info.room_name,
                     node: to_vertex_info.node_name,
-                    // node: debug_info,
                     from_node_id: from_vertex_info.node_id,
                     to_node_id: to_vertex_info.node_id,
                     obstacles_bitmask: to_obstacles_mask,
@@ -4602,7 +4516,6 @@ impl<'a> Randomizer<'a> {
                         Some(local_state.power_bombs_used)
                     },
                 };
-                // info!("spoiler: {:?}", spoiler_entry);
                 route.push(spoiler_entry);
             }
             local_state = new_local_state;
@@ -4646,7 +4559,6 @@ impl<'a> Randomizer<'a> {
             route[0].power_bombs_used = None;
         }
 
-        // info!("local: {:?}", local_state);
         route
     }
 
@@ -4655,9 +4567,6 @@ impl<'a> Randomizer<'a> {
         state: &RandomizationState,
         vertex_id: usize,
     ) -> (Vec<SpoilerRouteEntry>, Vec<SpoilerRouteEntry>) {
-        // info!("vertex_id: {}", vertex_id);
-        // info!("forward: {:?}", state.debug_data.as_ref().unwrap().forward.local_states[vertex_id]);
-        // info!("reverse: {:?}", state.debug_data.as_ref().unwrap().reverse.local_states[vertex_id]);
         let forward = &state.debug_data.as_ref().unwrap().forward;
         let reverse = &state.debug_data.as_ref().unwrap().reverse;
         let global_state = &state.debug_data.as_ref().unwrap().global_state;
@@ -4667,7 +4576,6 @@ impl<'a> Randomizer<'a> {
             get_spoiler_route(forward, vertex_id, forward_cost_idx);
         let reverse_link_idxs: Vec<LinkIdx> =
             get_spoiler_route(reverse, vertex_id, reverse_cost_idx);
-        // info!("obtain");
         let obtain_route = self.get_spoiler_route(
             global_state,
             LocalState::new(),
@@ -4675,7 +4583,6 @@ impl<'a> Randomizer<'a> {
             &self.difficulty_tiers[0],
             false,
         );
-        // info!("return");
         let return_route = self.get_spoiler_route(
             global_state,
             LocalState::new(),
@@ -4852,7 +4759,6 @@ impl<'a> Randomizer<'a> {
         _flag_vertex_id: usize,
         flag_id: FlagId,
     ) -> SpoilerFlagSummary {
-        // let flag_vertex_info = self.get_vertex_info(flag_vertex_id);
         SpoilerFlagSummary {
             flag: self.game_data.flag_isv.keys[flag_id].to_string(),
         }
@@ -4902,7 +4808,6 @@ impl<'a> Randomizer<'a> {
                 if !state.item_location_state[i].collected
                     && new_state.item_location_state[i].collected
                 {
-                    // info!("Item: {item:?}");
                     let item_vertex_id =
                         state.item_location_state[i].bireachable_vertex_id.unwrap();
                     let tier = new_state.item_location_state[i].difficulty_tier;

--- a/rust/src/randomize/run_speed.rs
+++ b/rust/src/randomize/run_speed.rs
@@ -19,7 +19,7 @@ fn linear_interpolate(x: f32, table: &[(i32, i32)]) -> f32 {
     if x >= table.last().unwrap().0 as f32 {
         return table.last().unwrap().1 as f32;
     }
-    let i = match table.binary_search_by_key(&(x as i32), |(x, y)| *x) {
+    let i = match table.binary_search_by_key(&(x as i32), |(x, _)| *x) {
         Ok(i) => i,
         Err(i) => i - 1,
     };

--- a/rust/src/seed_repository.rs
+++ b/rust/src/seed_repository.rs
@@ -73,11 +73,8 @@ impl SeedRepository {
         let path = object_store::path::Path::parse(
             self.base_path.clone() + seed_name + "/" + filename.as_str() + ".zstd",
         )?;
-        // info!("Compressing {}", filename);
         let compressed_data = zstd::bulk::compress(&data, 15)?;
-        // info!("Writing {}", filename);
         self.object_store.put(&path, compressed_data.into()).await?;
-        // info!("Done with {}", filename);
         Ok(())
     }
 

--- a/rust/src/spoiler_map.rs
+++ b/rust/src/spoiler_map.rs
@@ -12,22 +12,6 @@ use crate::{
     },
 };
 
-// fn read_tile_2bpp(rom: &Rom, base_addr: usize, idx: usize) -> Result<[[u8; 8]; 8]> {
-//     let mut out: [[u8; 8]; 8] = [[0; 8]; 8];
-//     for y in 0..8 {
-//         let addr = base_addr + idx * 16 + y * 2;
-//         let data_low = rom.read_u8(addr)?;
-//         let data_high = rom.read_u8(addr + 1)?;
-//         for x in 0..8 {
-//             let bit_low = (data_low >> (7 - x)) & 1;
-//             let bit_high = (data_high >> (7 - x)) & 1;
-//             let c = bit_low | (bit_high << 1);
-//             out[y][x] = c as u8;
-//         }
-//     }
-//     Ok(out)
-// }
-
 fn read_tile_4bpp(rom: &Rom, base_addr: usize, idx: usize) -> Result<[[u8; 8]; 8]> {
     let mut out: [[u8; 8]; 8] = [[0; 8]; 8];
     for y in 0..8 {
@@ -52,7 +36,6 @@ fn render_tile(rom: &Rom, tilemap_word: u16, map_area: usize) -> Result<[[u8; 8]
     let idx = (tilemap_word & 0x3FF) as usize;
     let x_flip = tilemap_word & 0x4000 != 0;
     let y_flip = tilemap_word & 0x8000 != 0;
-    // let tile = read_tile_2bpp(rom, snes2pc(0x9AB200), idx)?;
     let tile = read_tile_4bpp(rom, snes2pc(TILE_GFX_ADDR_4BPP + map_area * 0x10000), idx)?;
     let mut out = [[0u8; 8]; 8];
     for y in 0..8 {

--- a/rust/src/traverse.rs
+++ b/rust/src/traverse.rs
@@ -435,11 +435,6 @@ pub fn apply_ridley_requirement(
         // already required to reach the boss node from the doors.
         // Include time pre- and post-fight when Samus must still take heat damage:
         let heat_time = time + 16.0;
-        // let heat_energy_used = if global.items[Item::Gravity as usize] {
-        //     (heat_time * 7.5) as Capacity
-        // } else {
-        //     (heat_time * 15.0) as Capacity
-        // };
         let heat_energy_used = (heat_time * 15.0) as Capacity;
         local.energy_used += heat_energy_used;
     }
@@ -1052,11 +1047,6 @@ pub fn apply_requirement(
             // We're ignoring this for now. It should be safe because all strats relying on a "not" flag will be
             // guarded by "canRiskPermanentLossOfAccess" if there is not an alternative strat with the flag set.
             Some(local)
-            // if !global.flags[*flag_id] {
-            //     Some(local)
-            // } else {
-            //     None
-            // }
         }
         Requirement::Objective(obj_id) => {
             if is_objective_complete(global, difficulty, game_data, *obj_id) {
@@ -1121,7 +1111,6 @@ pub fn apply_requirement(
             let varia = global.items[Item::Varia as usize];
             let gravity = global.items[Item::Gravity as usize];
             let mut new_local = local;
-            // if gravity {
             if gravity && varia {
                 Some(new_local)
             } else if gravity || varia {
@@ -1174,11 +1163,6 @@ pub fn apply_requirement(
                 validate_energy_no_auto_reserve(new_local, global, game_data)
             }
         }
-        // Requirement::Energy(count) => {
-        //     let mut new_local = local;
-        //     new_local.energy_used += count;
-        //     validate_energy(new_local, global)
-        // },
         Requirement::Missiles(count) => {
             let mut new_local = local;
             new_local.missiles_used += *count;
@@ -1968,18 +1952,6 @@ pub fn traverse(
     };
 
     while modified_vertices.len() > 0 {
-        // let mut cnt = 0;
-        // let mut total_cost = 0.0;
-        // for v in 0..result.cost.len() {
-        //     for k in 0..NUM_COST_METRICS {
-        //         if f32::is_finite(result.cost[v][k]) {
-        //             cnt += 1;
-        //             total_cost += result.cost[v][k];
-        //         }
-        //     }
-        // }
-        // println!("modified vertices: {}, cnt_finite: {}, cost={}", modified_vertices.len(), cnt, total_cost);
-
         let mut new_modified_vertices: HashMap<usize, [bool; NUM_COST_METRICS]> = HashMap::new();
         for (&src_id, &modified_costs) in &modified_vertices {
             let src_local_state_arr = result.local_states[src_id];
@@ -2006,19 +1978,6 @@ pub fn traverse(
                         locked_door_data,
                     ) {
                         let dst_new_cost_arr = compute_cost(dst_new_local_state, global);
-
-                        // for k in dst_new_cost_arr {
-                        //     if k < 0.0 {
-                        //         println!("{:?}", link);
-                        //         println!("{:?} {:?}", game_data.vertex_isv.keys[link.from_vertex_id], game_data.vertex_isv.keys[link.to_vertex_id]);
-                        //         panic!("negative cost");
-                        //     }
-                        // }
-
-                        // let debug_vertex_id = 13452;
-                        // if !reverse && dst_id == debug_vertex_id {
-                        //     println!("{}: {:?}", dst_id, dst_new_local_state);
-                        // }
 
                         let new_step_trail = StepTrail {
                             prev_trail_id: src_trail_id,
@@ -2064,10 +2023,6 @@ pub fn traverse(
         }
         modified_vertices = new_modified_vertices;
     }
-
-    // for x in &result.local_state_history {
-    //     println!("{}", x.len());
-    // }
 
     result
 }

--- a/rust/src/traverse.rs
+++ b/rust/src/traverse.rs
@@ -307,7 +307,6 @@ fn apply_draygon_requirement(
         if net_dps < 0.0 {
             net_dps = 0.0;
         }
-        let total_damage = (net_dps * time) as Capacity;
         // We don't account for resources used, since they can be farmed or picked up after the fight, and we don't
         // want the fight to go out of logic due to not saving enough Missiles to open some red doors for example.
         let result = LocalState {
@@ -1889,11 +1888,7 @@ pub fn get_bireachable_idxs(
 
 // If the given vertex is reachable, returns a cost metric index (between 0 and NUM_COST_METRICS),
 // indicating a forward route. Otherwise returns None.
-pub fn get_one_way_reachable_idx(
-    global: &GlobalState,
-    vertex_id: usize,
-    forward: &TraverseResult,
-) -> Option<usize> {
+pub fn get_one_way_reachable_idx(vertex_id: usize, forward: &TraverseResult) -> Option<usize> {
     for forward_cost_idx in 0..NUM_COST_METRICS {
         let forward_state = forward.local_states[vertex_id][forward_cost_idx];
         if is_reachable_state(forward_state) {

--- a/rust/src/web.rs
+++ b/rust/src/web.rs
@@ -85,7 +85,6 @@ pub struct AppData {
     pub notable_gif_listing: HashSet<String>,
     pub samus_sprite_categories: Vec<SamusSpriteCategory>,
     pub logic_data: LogicData,
-    // pub samus_customizer: SamusSpriteCustomizer,
     pub debug: bool,
     pub version_info: VersionInfo,
     pub static_visualizer: bool,

--- a/rust/src/web/logic.rs
+++ b/rust/src/web/logic.rs
@@ -128,8 +128,6 @@ fn list_room_diagram_files() -> HashMap<usize, String> {
                     continue;
                 }
                 let room_id: usize = str::parse(segments[2]).unwrap();
-                // let img = image::open(path).unwrap();
-                // println!("{:?}", img.dimensions());
                 out.insert(room_id, path_string);
             }
             Err(e) => panic!("Failure reading room diagrams: {:?}", e),
@@ -322,7 +320,6 @@ pub fn strip_name(s: &str) -> String {
         out += &stripped_word;
     }
     out
-    // s.chars().filter(|x| x.is_ascii_alphanumeric()).collect()
 }
 
 fn get_difficulty_config(preset: &PresetData) -> DifficultyConfig {
@@ -532,7 +529,6 @@ fn get_strat_difficulty(
 
         let key = (room_id, from_node_id, to_node_id, strat_name.clone());
         if !links_by_ids.contains_key(&key) {
-            // println!("`links_by_ids` is missing key {:?}", key);
             return difficulty_configs.len();
         }
         for link in &links_by_ids[&key] {
@@ -685,7 +681,6 @@ fn make_room_template<'a>(
         };
         room_strats.push(strat);
     }
-    // let shape = *game_data.room_shape.get(&room_id).unwrap_or(&(1, 1));
     let difficulty_names: Vec<String> = presets.iter().map(|x| x.preset.name.clone()).collect();
 
     RoomTemplate {

--- a/rust/src/web/logic.rs
+++ b/rust/src/web/logic.rs
@@ -19,7 +19,7 @@ use crate::traverse::{apply_requirement, GlobalState, LocalState, LockedDoorData
 use super::{PresetData, VersionInfo, HQ_VIDEO_URL_ROOT};
 
 #[derive(Clone)]
-struct RoomStrat<'a> {
+struct RoomStrat {
     room_name: String,
     room_name_stripped: String,
     area: String,
@@ -41,7 +41,6 @@ struct RoomStrat<'a> {
     unlocks_doors: Option<String>,
     difficulty_idx: usize,
     difficulty_name: String,
-    notable_gif_listing: &'a HashSet<String>,
 }
 
 #[derive(Template, Clone)]
@@ -56,7 +55,7 @@ struct RoomTemplate<'a> {
     area: String,
     room_diagram_path: String,
     nodes: Vec<(usize, String)>,
-    strats: Vec<RoomStrat<'a>>,
+    strats: Vec<RoomStrat>,
     room_json: String,
     notable_gif_listing: &'a HashSet<String>,
     hq_video_url_root: String,
@@ -72,10 +71,9 @@ struct TechTemplate<'a> {
     tech_dependencies: String,
     tech_difficulty_idx: usize,
     tech_difficulty_name: String,
-    strats: Vec<RoomStrat<'a>>,
+    strats: Vec<RoomStrat>,
     tech_gif_listing: &'a HashSet<String>,
     notable_gif_listing: &'a HashSet<String>,
-    area_order: Vec<String>,
     hq_video_url_root: String,
 }
 
@@ -85,12 +83,10 @@ struct StratTemplate<'a> {
     version_info: VersionInfo,
     room_id: usize,
     room_name: String,
-    room_name_stripped: String,
     room_name_url_encoded: String,
-    area: String,
     room_diagram_path: String,
     strat_name: String,
-    strat: RoomStrat<'a>,
+    strat: RoomStrat,
     notable_gif_listing: &'a HashSet<String>,
     hq_video_url_root: String,
 }
@@ -267,7 +263,7 @@ fn make_tech_templates<'a>(
         let tech_name = game_data.tech_isv.keys[tech_idx].clone();
         let tech_note = game_data.tech_description[&tech_name].clone();
         let tech_dependencies = game_data.tech_dependencies[&tech_name].join(", ");
-        let mut strats: Vec<RoomStrat<'a>> = vec![];
+        let mut strats: Vec<RoomStrat> = vec![];
         let mut difficulty_idx = global_states.len();
 
         for (i, global) in global_states.iter().enumerate() {
@@ -308,7 +304,6 @@ fn make_tech_templates<'a>(
             strats,
             tech_gif_listing: tech_gif_listing,
             notable_gif_listing: notable_gif_listing,
-            area_order: area_order.to_vec(),
             hq_video_url_root: hq_video_url_root.to_string(),
         };
         tech_templates.push(template);
@@ -687,7 +682,6 @@ fn make_room_template<'a>(
             resets_obstacles,
             difficulty_idx,
             difficulty_name,
-            notable_gif_listing,
         };
         room_strats.push(strat);
     }
@@ -713,7 +707,7 @@ fn make_room_template<'a>(
 
 fn make_strat_template<'a>(
     room: &RoomTemplate<'a>,
-    strat: &RoomStrat<'a>,
+    strat: &RoomStrat,
     notable_gif_listing: &'a HashSet<String>,
     hq_video_url_root: &str,
     version_info: &VersionInfo,
@@ -722,9 +716,7 @@ fn make_strat_template<'a>(
         version_info: version_info.clone(),
         room_id: room.room_id,
         room_name: room.room_name.clone(),
-        room_name_stripped: room.room_name_stripped.clone(),
         room_name_url_encoded: room.room_name_url_encoded.clone(),
-        area: room.area.clone(),
         room_diagram_path: room.room_diagram_path.clone(),
         strat_name: strat.strat_name.clone(),
         strat: strat.clone(),


### PR DESCRIPTION
`nom` (used by the `ips` crate) was also updated to fix a warning about semicolons in macros. 
More info here: https://github.com/rust-bakery/nom/pull/1657

With this, all compiler warnings are gone!