### PR TITLE
Web/Customize: Fix non-checked controller settings

### DIFF
--- a/rust/maprando/templates/seed/controller_settings.html
+++ b/rust/maprando/templates/seed/controller_settings.html
@@ -29,7 +29,7 @@
         </div>
         <div class="col-md-9 btn-group p-0" role="group">
             {% for button in buttons.iter() %}
-            {% let checked = "" %}{% if button == default %}{% let checked = "checked" %}{% endif %}
+            {% let checked %}{% if button == default %}{% let checked = "checked" %}{% else %}{% let checked = "" %}{% endif %}
             <input type="radio" class="btn-check" id="{{+ form_name }}{{+ button }}" name="{{+ form_name }}" value="{{+ button }}" {{+ checked }}>
             <label class="btn btn-outline-primary" for="{{+ form_name }}{{+ button }}" onclick="swapButtonAssignment(this)">{{+ button }}</label>
             {% endfor %}
@@ -42,7 +42,7 @@
     </div>
     <div class="col-md-9 btn-group p-0" style="overflow-x: auto" role="group">
         {% for (button, button_display) in all_buttons.iter() %}
-            {% let checked = "" %}{% if ["L", "R", "Start", "Select"].contains(button) %}{% let checked = "checked" %}{% endif %}
+            {% let checked %}{% if ["L", "R", "Start", "Select"].contains(button) %}{% let checked = "checked" %}{% else %}{% let checked = "" %}{% endif %}
             <input type="checkbox" class="btn-check" id="quickReload{{+ button }}" name="quick_reload_{{+ button.to_lowercase() }}" {{+ checked }}>
             {% if button == "X"|as_ref %}
             <label class="btn btn-outline-primary me-1" for="quickReload{{+ button }}">{{+ button_display }}</label>
@@ -60,7 +60,7 @@
     </div>
     <div class="col-md-9 btn-group p-0" style="overflow-x: auto" role="group">
         {% for (button, button_display) in all_buttons %}
-            {% let checked = "" %}{% if ["L", "R", "Up", "X"].contains(button) %}{% let checked = "checked" %}{% endif %}
+            {% let checked %}{% if ["L", "R", "Up", "X"].contains(button) %}{% let checked = "checked" %}{% else %}{% let checked = "" %}{% endif %}
             <input type="checkbox" class="btn-check" id="spinLock{{+ button }}" name="spin_lock_{{+ button.to_lowercase() }}" {{+ checked }}>
             {% if button == "X" %}
             <label class="btn btn-outline-primary me-1" for="spinLock{{+ button }}">{{+ button_display }}</label>


### PR DESCRIPTION
A syntax logic error. Unfortunately there are no warnings of unused code in proc macros.
Here's the different generated code:

| main | pr |
| - | - |
| ![image](https://github.com/user-attachments/assets/74d8c772-3341-49c5-b9d3-7757ba4b68da) | ![image](https://github.com/user-attachments/assets/89755691-79c5-4269-a1d7-2ca5f62b2af2) |

Writing `{% checked = "checked" %}` doesn't work, so what this PR does has to be done instead, as shown here: https://djc.github.io/askama/template_syntax.html#assignments