### PR TITLE
Web: Auto-unlock spoilers after a certain duration

### DIFF
--- a/rust/maprando-web/src/web/randomize.rs
+++ b/rust/maprando-web/src/web/randomize.rs
@@ -1,6 +1,6 @@
 mod helpers;
 
-use crate::web::{AppData, VERSION};
+use crate::web::{seed::SeedData, AppData, VERSION};
 use actix_easy_multipart::{bytes::Bytes, text::Text, MultipartForm};
 use actix_web::{
     http::header::{self},
@@ -20,55 +20,7 @@ use maprando::{
     },
 };
 use rand::{RngCore, SeedableRng};
-use serde_derive::{Deserialize, Serialize};
 use std::time::{Instant, SystemTime};
-
-#[derive(Serialize, Deserialize)]
-struct SeedData {
-    version: usize,
-    timestamp: usize,
-    peer_addr: String,
-    http_headers: serde_json::Map<String, serde_json::Value>,
-    random_seed: usize,
-    map_seed: usize,
-    door_randomization_seed: usize,
-    item_placement_seed: usize,
-    race_mode: bool,
-    preset: Option<String>,
-    item_progression_preset: Option<String>,
-    difficulty: DifficultyConfig,
-    quality_of_life_preset: Option<String>,
-    supers_double: bool,
-    mother_brain_fight: String,
-    escape_enemies_cleared: bool,
-    escape_refill: bool,
-    escape_movement_items: bool,
-    mark_map_stations: bool,
-    transition_letters: bool,
-    item_markers: String,
-    item_dot_change: String,
-    all_items_spawn: bool,
-    acid_chozo: bool,
-    buffed_drops: bool,
-    fast_elevators: bool,
-    fast_doors: bool,
-    fast_pause_menu: bool,
-    respin: bool,
-    infinite_space_jump: bool,
-    momentum_conservation: bool,
-    objectives: String,
-    doors: String,
-    start_location_mode: String,
-    map_layout: String,
-    save_animals: String,
-    early_save: bool,
-    area_assignment: String,
-    wall_jump: String,
-    etank_refill: String,
-    maps_revealed: String,
-    vanilla_map: bool,
-    ultra_low_qol: bool,
-}
 
 #[derive(Template)]
 #[template(path = "errors/missing_input_rom.html")]

--- a/rust/maprando-web/src/web/seed.rs
+++ b/rust/maprando-web/src/web/seed.rs
@@ -3,11 +3,78 @@ mod get_seed_file;
 mod unlock_seed;
 mod view_seed;
 
+use super::AppData;
+use maprando::randomize::DifficultyConfig;
+use serde::{Deserialize, Serialize};
+
 pub fn scope() -> actix_web::Scope {
     actix_web::web::scope("/seed")
         .service(view_seed::view_seed)
         .service(get_seed_file::get_seed_file)
         .service(customize_seed::customize_seed)
-        .service(unlock_seed::unlock_seed)
+        .service(unlock_seed::unlock_request)
         .service(view_seed::view_seed_redirect)
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SeedData {
+    pub version: usize,
+    pub timestamp: usize,
+    pub peer_addr: String,
+    pub http_headers: serde_json::Map<String, serde_json::Value>,
+    pub random_seed: usize,
+    pub map_seed: usize,
+    pub door_randomization_seed: usize,
+    pub item_placement_seed: usize,
+    pub race_mode: bool,
+    pub preset: Option<String>,
+    pub item_progression_preset: Option<String>,
+    pub difficulty: DifficultyConfig,
+    pub quality_of_life_preset: Option<String>,
+    pub supers_double: bool,
+    pub mother_brain_fight: String,
+    pub escape_enemies_cleared: bool,
+    pub escape_refill: bool,
+    pub escape_movement_items: bool,
+    pub mark_map_stations: bool,
+    pub transition_letters: bool,
+    pub item_markers: String,
+    pub item_dot_change: String,
+    pub all_items_spawn: bool,
+    pub acid_chozo: bool,
+    pub buffed_drops: bool,
+    pub fast_elevators: bool,
+    pub fast_doors: bool,
+    pub fast_pause_menu: bool,
+    pub respin: bool,
+    pub infinite_space_jump: bool,
+    pub momentum_conservation: bool,
+    pub objectives: String,
+    pub doors: String,
+    pub start_location_mode: String,
+    pub map_layout: String,
+    pub save_animals: String,
+    pub early_save: bool,
+    pub area_assignment: String,
+    pub wall_jump: String,
+    pub etank_refill: String,
+    pub maps_revealed: String,
+    pub vanilla_map: bool,
+    pub ultra_low_qol: bool,
+}
+
+impl SeedData {
+    /// Returns the [`SeedData`] of the specified seed from the seed repository.
+    ///
+    /// # Panics
+    /// Panics if the specified seed doesn't exist.
+    async fn from_repository(app_data: &AppData, seed_name: &str) -> SeedData {
+        let bytes = app_data
+            .seed_repository
+            .get_file(seed_name, "seed_data.json")
+            .await
+            .unwrap();
+        let json_string = String::from_utf8(bytes).unwrap();
+        serde_json::from_str(&json_string).unwrap()
+    }
 }


### PR DESCRIPTION
The check happens when the get request for the main seed page is called. Auto-unlocks if 12 hours has passed.

In `view_seed`, use `spoiler_token` to check if it's a race seed, and `unlocked_timestamp_str` to see if it's already unlocked.