### PR TITLE
Add overflow checks to boss_requirements.rs

### DIFF
--- a/rust/maprando-logic/src/boss_requirements.rs
+++ b/rust/maprando-logic/src/boss_requirements.rs
@@ -66,6 +66,9 @@ pub fn apply_phantoon_requirement(
         net_dps = 0.0;
     }
 
+    // Overflow safeguard - bail here if Samus takes calamitous damage.
+    if net_dps * kill_time > 10000.0 { return None; }
+
     local.energy_used += (net_dps * kill_time) as Capacity;
 
     validate_energy(local, inventory, can_manage_reserves)
@@ -165,6 +168,8 @@ pub fn apply_draygon_requirement(
         if net_dps < 0.0 {
             net_dps = 0.0;
         }
+        // Overflow safeguard - bail here if Samus takes calamitous damage.
+        if net_dps * time > 10000.0 { return None; }
         // We don't account for resources used, since they can be farmed or picked up after the fight, and we don't
         // want the fight to go out of logic due to not saving enough Missiles to open some red doors for example.
         let result = LocalState {
@@ -286,6 +291,8 @@ pub fn apply_ridley_requirement(
         (true, true) => 0.5 - 0.5 * proficiency,
     };
     let damage = base_ridley_attack_dps * hit_rate * time;
+    // Overflow safeguard - bail here if Samus takes calamitous damage.
+    if damage > 10000.0 { return None; }
     local.energy_used += (damage / suit_damage_factor(inventory) as f32) as Capacity;
 
     if !inventory.items[Item::Varia as usize] {
@@ -409,6 +416,8 @@ pub fn apply_botwoon_requirement(
         };
         let hits = f32::round(base_hit_rate * hit_rate_multiplier * time);
         let damage_per_hit = 96.0 / suit_damage_factor(inventory) as f32;
+        // Overflow safeguard - bail here if Samus takes calamitous damage.
+        if hits * damage_per_hit > 10000.0 { return None; }
         local.energy_used += (hits * damage_per_hit) as Capacity;
     }
 
@@ -517,6 +526,8 @@ pub fn apply_mother_brain_2_requirement(
             local.energy_used += 600;
         }
     }
+    // Overflow safeguard - bail here if Samus takes calamitous damage.
+    if damage > 10000.0 { return None; }
 
     validate_energy(local, inventory, can_manage_reserves)
 }


### PR DESCRIPTION
Adds check for overflow when converting the calculated damage to Samus into the `Capacity`/`i16` storage.

Fixes an issue where Ridley can result in energy consumption overflow (resulting in negative energy used) in certain Custom difficulty settings, e.g. any combining `canBeVeryPatient`, `Ridley without Heat Protection` and a Ridley proficiency of `0.54` or less will overflow the energy consumption at 1% `Charge Beam` condition, potentially producing an unbeatable seed.

These conditions can't occur on any named preset, so it is exclusive to Custom difficulties.
- `Ridley without Heat Protection` is excluded on all presets below `Very Hard`. `Very Hard` itself has a proficiency of 0.7 which is high enough to avoid the overflow. Without this, therefore mandating Varia on top of Power Beam, the proficiency would have to be below 0.16 to risk overflow.
- `canBeVeryPatient` - effectively required for any Ridley fight using only Charge Power Beam - is excluded from all presets below `Insane`, which has a proficiency value of 1.0 which is high enough to avoid the overflow. Because energy is a function of time spent in fight, any fight long enough to overflow is long enough to need `canBeVeryPatient`.