### PR TITLE
Boss Calc: Style fixes for mobile

### DIFF
--- a/rust/maprando-web/templates/logic/boss_calculator.html
+++ b/rust/maprando-web/templates/logic/boss_calculator.html
@@ -15,7 +15,7 @@
         </div>
 
         <div id="boss-selector" class="row">
-            <div class="d-flex justify-content-around my-2">
+            <div class="d-flex justify-content-around flex-wrap my-2">
                 <style>
                     .boss-icon {
                         width: 128px;
@@ -54,7 +54,7 @@
                 <label for="boss-proficiency" class="col-6 col-form-label">Boss proficiency<br>
                     <small>(Skill level at the boss fights, between 0 and 1)</small>
                 </label>
-                <div class="col-2 my-2">
+                <div class="col-sm-3 my-2">
                     <input type="number" class="form-control" id="boss-proficiency" min="0" max="1" step="0.05" id="proficiency" value="0">
                 </div>
             </div>


### PR DESCRIPTION
The difficulty/techs can be scrolled sideways, which is consistent with the other pages on the site.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/dbd3a32e-fe38-4b8c-8096-70eb95270e00) | ![after](https://github.com/user-attachments/assets/4be53eee-1ffd-4e14-ade1-9e32e293b381) |
