### PR TITLE
Update map_tiles.json

### DIFF
--- a/rust/data/map_tiles.json
+++ b/rust/data/map_tiles.json
@@ -104,7 +104,7 @@
                 {"coords": [1, 1], "left": "empty", "right": "empty", "top": "qolEmpty", "bottom": "wall"},
                 {"coords": [2, 1], "left": "empty", "right": "empty", "top": "wall", "bottom": "wall"},
                 {"coords": [3, 1], "left": "empty", "right": "empty", "top": "wall", "bottom": "wall"},
-                {"coords": [4, 1], "left": "empty", "right": "door", "top": "wall", "bottom": "wall"}
+                {"coords": [4, 1], "left": "empty", "right": "qolDoor", "top": "wall", "bottom": "wall"}
             ]
         },
         {

--- a/rust/data/map_tiles.json
+++ b/rust/data/map_tiles.json
@@ -742,7 +742,7 @@
                 {"coords": [0, 0], "left": "door", "right": "empty", "top": "wall", "bottom": "passage"},
                 {"coords": [1, 0], "left": "empty", "right": "empty", "top": "wall", "bottom": "wall"},
                 {"coords": [2, 0], "left": "empty", "right": "door", "top": "wall", "bottom": "wall"},
-                {"coords": [0, 1], "left": "wall", "right": "wall", "top": "empty", "bottom": "wall", "interior": "item"}
+                {"coords": [0, 1], "left": "wall", "right": "wall", "top": "qolEmpty", "bottom": "wall", "interior": "item"}
             ]
         },
         {
@@ -2765,7 +2765,7 @@
                 {"coords": [3, 1], "left": "empty", "right": "empty", "top": "wall", "bottom": "wall"},
                 {"coords": [4, 1], "left": "empty", "right": "wall", "top": "wall", "bottom": "wall", "interior": "event"},
                 {"coords": [5, 1], "left": "wall", "right": "wall", "top": "empty", "bottom": "empty"},
-                {"coords": [1, 2], "left": "door", "right": "passage", "top": "empty", "bottom": "wall"},
+                {"coords": [1, 2], "left": "door", "right": "passage", "top": "qolEmpty", "bottom": "wall"},
                 {"coords": [2, 2], "left": "empty", "right": "empty", "top": "wall", "bottom": "wall"},
                 {"coords": [3, 2], "left": "empty", "right": "passage", "top": "wall", "bottom": "wall", "interior": "hiddenItem"},
                 {"coords": [4, 2], "left": "empty", "right": "empty", "top": "wall", "bottom": "wall"},


### PR DESCRIPTION
Checked the Ultra Low QoL as well.
Looks like there were 2 errors in the old method that are now fixed:
- Botwoon's Room had a single thick passage wall
- Ridley's Room was drawn as heated