### PR TITLE
Lower some waterlines by 1px

### DIFF
--- a/rust/data/map_tiles.json
+++ b/rust/data/map_tiles.json
@@ -873,7 +873,7 @@
             "roomId": 7,
             "roomName": "The Moat",
             "liquidType": "water",
-            "liquidLevel": 0.625,
+            "liquidLevel": 0.75,
             "mapTiles": [
                 {"coords": [0, 0], "left": "door", "right": "empty", "top": "wall", "bottom": "empty", "interior": "item"},
                 {"coords": [1, 0], "left": "empty", "right": "door", "top": "wall", "bottom": "empty"},
@@ -1597,7 +1597,7 @@
             "roomId": 208,
             "roomName": "East Sand Hole",
             "liquidType": "water",
-            "liquidLevel": 0.625,
+            "liquidLevel": 0.75,
             "mapTiles": [
                 {"coords": [0, 0], "left": "wall", "right": "empty", "top": "sand", "bottom": "empty", "interior": "item"},
                 {"coords": [1, 0], "left": "empty", "right": "wall", "top": "wall", "bottom": "empty"},
@@ -1697,7 +1697,7 @@
             "roomId": 209,
             "roomName": "West Sand Hole",
             "liquidType": "water",
-            "liquidLevel": 0.625,
+            "liquidLevel": 0.75,
             "mapTiles": [
                 {"coords": [0, 0], "left": "wall", "right": "empty", "top": "wall", "bottom": "empty", "interior": "doubleItem"},
                 {"coords": [1, 0], "left": "empty", "right": "wall", "top": "sand", "bottom": "empty"},
@@ -2086,7 +2086,7 @@
             "roomId": 131,
             "roomName": "Grapple Tutorial Room 3",
             "liquidType": "water",
-            "liquidLevel": 0.625,
+            "liquidLevel": 0.75,
             "mapTiles": [
                 {"coords": [0, 0], "left": "door", "right": "empty", "top": "wall", "bottom": "empty"},
                 {"coords": [1, 0], "left": "empty", "right": "empty", "top": "wall", "bottom": "empty"},
@@ -2986,7 +2986,7 @@
             "roomId": 167,
             "roomName": "Wrecked Ship Energy Tank Room",
             "liquidType": "water",
-            "liquidLevel": 0.625,
+            "liquidLevel": 0.75,
             "mapTiles": [
                 {"coords": [0, 0], "left": "wall", "right": "empty", "top": "wall", "bottom": "empty", "interior": "item"},
                 {"coords": [1, 0], "left": "empty", "right": "empty", "top": "wall", "bottom": "empty"},


### PR DESCRIPTION
We want to keep all map tiles with water to have at least 2 px of water on a given tile (1 is hard to see and won't look great). When entering rooms where the map has a drop-off into water, the map tile shows 3 px of water (since the bottom row isn't a wall). Some of these rooms, where the water doesn't feel like it should be as high, have been lowered by 1 px. This also reduces the water/item dot interaction, which is helpful. 