### PR TITLE
UI improvements for Item Pool and Starting Items

### DIFF
--- a/rust/maprando-web/src/web/generate.rs
+++ b/rust/maprando-web/src/web/generate.rs
@@ -20,6 +20,7 @@ struct GenerateTemplate<'a> {
     objective_presets_json: String,
     item_priorities: Vec<String>,
     item_pool_multiple: Vec<String>,
+    item_pool_single: Vec<String>,
     starting_items_multiple: Vec<String>,
     starting_items_single: Vec<String>,
     prioritizable_items: Vec<String>,
@@ -38,6 +39,28 @@ async fn generate(app_data: web::Data<AppData>) -> impl Responder {
         .into_iter()
         .map(|x| x.to_string())
         .collect();
+        
+    let item_pool_single: Vec<String> = [
+        "Charge",
+        "Ice",
+        "Wave",
+        "Spazer",
+        "Plasma",
+        "XRayScope",
+        "Morph",
+        "Bombs",
+        "Grapple",
+        "HiJump",
+        "SpeedBooster",
+        "SpringBall",
+        "SpaceJump",
+        "ScrewAttack",
+        "Varia",
+        "Gravity",
+    ]
+    .into_iter()
+    .map(|x| x.to_string())
+    .collect();
 
     let starting_items_multiple: Vec<String> =
         ["Missile", "ETank", "ReserveTank", "Super", "PowerBomb"]
@@ -157,6 +180,7 @@ async fn generate(app_data: web::Data<AppData>) -> impl Responder {
         item_placement_styles: vec!["Neutral", "Forced", "Local"],
         objective_groups: get_objective_groups(),
         item_pool_multiple,
+        item_pool_single,
         starting_items_multiple,
         starting_items_single,
         item_priorities: ["Early", "Default", "Late", "Never"]

--- a/rust/maprando-web/src/web/generate.rs
+++ b/rust/maprando-web/src/web/generate.rs
@@ -19,10 +19,8 @@ struct GenerateTemplate<'a> {
     qol_presets_json: String,
     objective_presets_json: String,
     item_priorities: Vec<String>,
-    item_pool_multiple: Vec<String>,
-    item_pool_single: Vec<String>,
-    starting_items_multiple: Vec<String>,
-    starting_items_single: Vec<String>,
+    item_names_multiple: Vec<String>,
+    item_names_single: Vec<String>,
     prioritizable_items: Vec<String>,
     tech_description: &'a HashMap<TechId, String>,
     tech_dependencies_str: &'a HashMap<TechId, String>,
@@ -35,40 +33,12 @@ struct GenerateTemplate<'a> {
 
 #[get("/generate")]
 async fn generate(app_data: web::Data<AppData>) -> impl Responder {
-    let item_pool_multiple: Vec<String> = ["Missile", "ETank", "ReserveTank", "Super", "PowerBomb"]
+    let item_names_multiple: Vec<String> = ["Missile", "ETank", "ReserveTank", "Super", "PowerBomb"]
         .into_iter()
         .map(|x| x.to_string())
         .collect();
         
-    let item_pool_single: Vec<String> = [
-        "Charge",
-        "Ice",
-        "Wave",
-        "Spazer",
-        "Plasma",
-        "XRayScope",
-        "Morph",
-        "Bombs",
-        "Grapple",
-        "HiJump",
-        "SpeedBooster",
-        "SpringBall",
-        "SpaceJump",
-        "ScrewAttack",
-        "Varia",
-        "Gravity",
-    ]
-    .into_iter()
-    .map(|x| x.to_string())
-    .collect();
-
-    let starting_items_multiple: Vec<String> =
-        ["Missile", "ETank", "ReserveTank", "Super", "PowerBomb"]
-            .into_iter()
-            .map(|x| x.to_string())
-            .collect();
-
-    let starting_items_single: Vec<String> = [
+    let item_names_single: Vec<String> = [
         "Charge",
         "Ice",
         "Wave",
@@ -179,10 +149,8 @@ async fn generate(app_data: web::Data<AppData>) -> impl Responder {
         progression_rates: vec!["Fast", "Uniform", "Slow"],
         item_placement_styles: vec!["Neutral", "Forced", "Local"],
         objective_groups: get_objective_groups(),
-        item_pool_multiple,
-        item_pool_single,
-        starting_items_multiple,
-        starting_items_single,
+        item_names_multiple,
+        item_names_single,
         item_priorities: ["Early", "Default", "Late", "Never"]
             .iter()
             .map(|x| x.to_string())

--- a/rust/maprando-web/src/web/generate.rs
+++ b/rust/maprando-web/src/web/generate.rs
@@ -151,7 +151,7 @@ async fn generate(app_data: web::Data<AppData>) -> impl Responder {
         objective_groups: get_objective_groups(),
         item_names_multiple,
         item_names_single,
-        item_priorities: ["Early", "Default", "Late", "Never"]
+        item_priorities: ["Early", "Default", "Late"]
             .iter()
             .map(|x| x.to_string())
             .collect(),

--- a/rust/maprando-web/src/web/generate.rs
+++ b/rust/maprando-web/src/web/generate.rs
@@ -51,6 +51,7 @@ async fn generate(app_data: web::Data<AppData>) -> impl Responder {
         "HiJump",
         "SpeedBooster",
         "SpringBall",
+        "WallJump",
         "SpaceJump",
         "ScrewAttack",
         "Varia",

--- a/rust/maprando-web/src/web/generate.rs
+++ b/rust/maprando-web/src/web/generate.rs
@@ -33,11 +33,12 @@ struct GenerateTemplate<'a> {
 
 #[get("/generate")]
 async fn generate(app_data: web::Data<AppData>) -> impl Responder {
-    let item_names_multiple: Vec<String> = ["Missile", "ETank", "ReserveTank", "Super", "PowerBomb"]
-        .into_iter()
-        .map(|x| x.to_string())
-        .collect();
-        
+    let item_names_multiple: Vec<String> =
+        ["Missile", "ETank", "ReserveTank", "Super", "PowerBomb"]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect();
+
     let item_names_single: Vec<String> = [
         "Charge",
         "Ice",

--- a/rust/maprando-web/templates/generate/help/progression/key_item_priority.html
+++ b/rust/maprando-web/templates/generate/help/progression/key_item_priority.html
@@ -11,10 +11,6 @@
           in the results, because of constraints that limit how early or late the randomizer can place a key item in any
           given situation, especially for lower settings of "Skill assumptions".</p>
 
-        <p><b>Warning</b>: If a key item's priority is set to "Never", that item will never be placed. Removing certain 
-          items can make it impossible to create a playable seed, causing the randomizer to take a long time and
-          eventually fail with an error.
-
         <h5>Details</h5>
         <p>At the beginning of each randomization attempt, an item priority order is determined by randomly shuffling
           all the item types, with a bias such that "Early" items (as selected below) tend to come before "Default"

--- a/rust/maprando-web/templates/generate/item_progression.html
+++ b/rust/maprando-web/templates/generate/item_progression.html
@@ -367,11 +367,10 @@
         height: 16px;
         background-image: url(/static/items.png);
         image-rendering: pixelated;
-        background-size: auto 100%;
-	background-clip: content-box;
-	padding-left: 0;
-	padding-right: 0;
-	margin-top: 9px;
+        padding-left: 0;
+        padding-right: 0;
+        margin-top: 12px;
+        transform: scale(1.75);
     }
     
     .itemIconCharge {

--- a/rust/maprando-web/templates/generate/item_progression.html
+++ b/rust/maprando-web/templates/generate/item_progression.html
@@ -294,6 +294,7 @@
                                 {% for item in prioritizable_items %}
                                     <div class="form-group row my-2">
                                         <label class="col-sm-4 col-form-label text-end" for="item_priority_{{+ item }}">{{+ item }}</label>
+                                        <span class="itemIcon itemIcon{{+ item }}"></span>
                                         <div id="itemPriority{{ item }}" class="col-sm-7 btn-group" role="group">
                                             {% for priority in item_priorities %}
                                                 <input type="radio" class="btn-check item-priority-input" name="item_priority_{{+ item }}" value="{{+ priority }}"
@@ -324,6 +325,7 @@
                                 {% for item in prioritizable_items %}
                                     <div id="fillerItems{{ item }}" class="form-group row my-2">
                                         <label class="col-sm-4 col-form-label text-end" for="filler_items_{{+ item }}">{{+ item }}</label>
+                                        <span class="itemIcon itemIcon{{+ item }}"></span>
                                         <div class="col-sm-7 btn-group" role="group">
                                             <input type="radio" class="btn-check filler-items-input" name="filler_items_{{+ item }}" value="No"
                                                 id="fillerItems{{+ item }}No" autocomplete="off" 

--- a/rust/maprando-web/templates/generate/item_progression.html
+++ b/rust/maprando-web/templates/generate/item_progression.html
@@ -198,6 +198,21 @@
                                         </div>
                                     </div>
                                 {% endfor %}
+                                {% for item in item_pool_single %}
+                                    <div class="form-group row my-2">
+                                        <label class="col-sm-2 col-form-label text-end" for="item_pool_{{+ item }}">{{+ item }}</label>
+                                        <div id="itemPool{{ item}}" class="col-sm-3 btn-group" role="group">
+                                            <input type="radio" class="btn-check item-pool-input-single" name="item_pool_{{+ item }}" value="No"
+                                                id="itemPool{{+ item }}No" autocomplete="off" 
+                                                onclick="itemPoolChanged()">
+                                            <label class="btn btn-outline-primary" for="itemPool{{+ item }}No">No</label>
+                                            <input type="radio" class="btn-check item-pool-input-single" name="item_pool_{{+ item }}" value="Yes"
+                                                id="itemPool{{+ item }}Yes" autocomplete="off" 
+                                                onclick="itemPoolChanged()" checked>
+                                            <label class="btn btn-outline-primary" for="itemPool{{+ item }}Yes">Yes</label>
+                                        </div>
+                                    </div>
+                                {% endfor %}
                             </div>
                         </div>
                     </div>

--- a/rust/maprando-web/templates/generate/item_progression.html
+++ b/rust/maprando-web/templates/generate/item_progression.html
@@ -191,19 +191,19 @@
                                 </div>
                                 {% for item in item_names_multiple %}
                                     <div class="form-group row m-2">
-                                        <label class="col-sm-2 col-form-label text-end" for="item_pool_min_{{+ item }}">{{+ item }}</label>
+                                        <label class="col-lg-3 col-form-label text-end" for="item_pool_min_{{+ item }}">{{+ item }}</label>
                                         <span class="itemIcon itemIcon{{+ item }}"></span>
-                                        <div class="col-sm-2">
+                                        <div class="col-lg-2">
                                             <input type="text" class="form-control item-pool-input-multiple" name="item_pool_{{+ item }}" id="itemPool{{+ item }}" 
                                             value="0" onchange="itemPoolChanged()">
                                         </div>
                                     </div>
                                 {% endfor %}
                                 {% for item in item_names_single %}
-                                    <div class="form-group row my-2">
-                                        <label class="col-sm-2 col-form-label text-end" for="item_pool_{{+ item }}">{{+ item }}</label>
+                                    <div class="form-group row m-2">
+                                        <label class="col-lg-3 col-form-label text-end" for="item_pool_{{+ item }}">{{+ item }}</label>
                                         <span class="itemIcon itemIcon{{+ item }}"></span>
-                                        <div id="itemPool{{ item}}" class="col-sm-3 btn-group" role="group">
+                                        <div id="itemPool{{ item}}" class="col-lg-2 btn-group" role="group">
                                             <input type="radio" class="btn-check item-pool-input-single" name="item_pool_{{+ item }}" value="No"
                                                 id="itemPool{{+ item }}No" autocomplete="off" 
                                                 onclick="itemPoolChanged()">

--- a/rust/maprando-web/templates/generate/item_progression.html
+++ b/rust/maprando-web/templates/generate/item_progression.html
@@ -142,7 +142,7 @@
                     <div class="col-lg-3 ml-0 mt-1 mb-1 align-items-center">
                         <button type="button" class="btn mr-1 px-2 py-1" data-bs-toggle="modal" data-bs-target="#itemPoolModal">
                             <i class="bi bi-question-circle"></i>
-                        </button>                          
+                        </button>
                         <label for="preset">Item pool</label>
                     </div>
                     <div id="itemPoolPreset" class="col-lg-3 btn-group mt-0" role="group">
@@ -191,8 +191,9 @@
                                 </div>
                                 {% for item in item_names_multiple %}
                                     <div class="form-group row m-2">
-                                        <label class="col-lg-3 col-form-label text-end" for="item_pool_min_{{+ item }}">{{+ item }}</label>
-                                        <div class="col-lg-2">
+                                        <label class="col-sm-2 col-form-label text-end" for="item_pool_min_{{+ item }}">{{+ item }}</label>
+                                        <span class="itemIcon itemIcon{{+ item }}"></span>
+                                        <div class="col-sm-2">
                                             <input type="text" class="form-control item-pool-input-multiple" name="item_pool_{{+ item }}" id="itemPool{{+ item }}" 
                                             value="0" onchange="itemPoolChanged()">
                                         </div>
@@ -201,6 +202,7 @@
                                 {% for item in item_names_single %}
                                     <div class="form-group row my-2">
                                         <label class="col-sm-2 col-form-label text-end" for="item_pool_{{+ item }}">{{+ item }}</label>
+                                        <span class="itemIcon itemIcon{{+ item }}"></span>
                                         <div id="itemPool{{ item}}" class="col-sm-3 btn-group" role="group">
                                             <input type="radio" class="btn-check item-pool-input-single" name="item_pool_{{+ item }}" value="No"
                                                 id="itemPool{{+ item }}No" autocomplete="off" 
@@ -249,6 +251,7 @@
                                 {% for item in item_names_multiple %}
                                     <div class="form-group row my-2">
                                         <label class="col-sm-2 col-form-label text-end" for="starting_item_{{+ item }}">{{+ item }}</label>
+                                        <span class="itemIcon itemIcon{{+ item }}"></span>
                                         <div class="col-sm-2">
                                             <input type="text" class="form-control starting-item-input-multiple" name="starting_item_{{+ item }}" id="startingItem{{+ item }}" 
                                             value="0" onchange="startingItemsChanged()">
@@ -258,6 +261,7 @@
                                 {% for item in item_names_single %}
                                     <div class="form-group row my-2">
                                         <label class="col-sm-2 col-form-label text-end" for="starting_item_{{+ item }}">{{+ item }}</label>
+                                        <span class="itemIcon itemIcon{{+ item }}"></span>
                                         <div id="startingItem{{ item}}" class="col-sm-3 btn-group" role="group">
                                             <input type="radio" class="btn-check starting-item-input-single" name="starting_item_{{+ item }}" value="No"
                                                 id="startingItem{{+ item }}No" autocomplete="off" 
@@ -353,6 +357,110 @@
         </div>
     </div>
 </div>
+<style>
+    .itemIcon {
+        display: inline-block;
+        position: relative;
+        width: 16px;
+        height: 16px;
+        background-image: url(/static/items.png);
+        image-rendering: pixelated;
+        background-size: auto 100%;
+	background-clip: content-box;
+	padding-left: 0;
+	padding-right: 0;
+	margin-top: 9px;
+    }
+    
+    .itemIconCharge {
+        background-position-x: calc(-8px * 10);
+    }
+
+    .itemIconVaria {
+        background-position-x: calc(-8px * 24);
+    }
+
+    .itemIconMorph {
+        background-position-x: calc(-8px * 38);
+    }
+
+    .itemIconHiJump {
+        background-position-x: calc(-8px * 14);
+    }
+
+    .itemIconMissile {
+        background-position-x: calc(-8px * 2);
+    }
+
+    .itemIconIce {
+        background-position-x: calc(-8px * 12);
+    }
+
+    .itemIconGravity {
+        background-position-x: calc(-8px * 26);
+    }
+
+    .itemIconBombs {
+        background-position-x: calc(-8px * 8);
+    }
+
+    .itemIconSpaceJump {
+        background-position-x: calc(-8px * 34);
+    }
+
+    .itemIconSuper {
+        background-position-x: calc(-8px * 4);
+    }
+
+    .itemIconWave {
+        background-position-x: calc(-8px * 18);
+    }
+
+    .itemIconSpringBall {
+        background-position-x: calc(-8px * 22);
+    }
+
+    .itemIconSpeedBooster {
+        background-position-x: calc(-8px * 16);
+    }
+
+    .itemIconPowerBomb {
+        background-position-x: calc(-8px * 6);
+    }
+
+    .itemIconSpazer {
+        background-position-x: calc(-8px * 20);
+    }
+
+    .itemIconGrapple {
+        background-position-x: calc(-8px * 32);
+    }
+
+    .itemIconScrewAttack {
+        background-position-x: calc(-8px * 36);
+    }
+
+    .itemIconWallJump {
+        background-position-x: calc(-8px * 42);
+    }
+
+    .itemIconETank {
+        background-position-x: calc(-8px * 0);
+    }
+
+    .itemIconPlasma {
+        background-position-x: calc(-8px * 30);
+    }
+
+    .itemIconXRayScope {
+        background-position-x: calc(-8px * 28);
+    }
+
+    .itemIconReserveTank {
+        background-position-x: calc(-8px * 40);
+    }
+
+</style>
 
 {% include "help/progression/rate.html" %}
 {% include "help/progression/item_placement.html" %}

--- a/rust/maprando-web/templates/generate/item_progression.html
+++ b/rust/maprando-web/templates/generate/item_progression.html
@@ -189,7 +189,7 @@
                                         {% endfor %}
                                     </div>
                                 </div>
-                                {% for item in item_pool_multiple %}
+                                {% for item in item_names_multiple %}
                                     <div class="form-group row m-2">
                                         <label class="col-lg-3 col-form-label text-end" for="item_pool_min_{{+ item }}">{{+ item }}</label>
                                         <div class="col-lg-2">
@@ -198,7 +198,7 @@
                                         </div>
                                     </div>
                                 {% endfor %}
-                                {% for item in item_pool_single %}
+                                {% for item in item_names_single %}
                                     <div class="form-group row my-2">
                                         <label class="col-sm-2 col-form-label text-end" for="item_pool_{{+ item }}">{{+ item }}</label>
                                         <div id="itemPool{{ item}}" class="col-sm-3 btn-group" role="group">
@@ -246,7 +246,7 @@
                             </h2>
                             <div id="collapseStartingItems" class="accordion-collapse collapse">
                                 <input type="hidden" id="json-starting-items" name="starting_item_json">
-                                {% for item in starting_items_multiple %}
+                                {% for item in item_names_multiple %}
                                     <div class="form-group row my-2">
                                         <label class="col-sm-2 col-form-label text-end" for="starting_item_{{+ item }}">{{+ item }}</label>
                                         <div class="col-sm-2">
@@ -255,7 +255,7 @@
                                         </div>
                                     </div>
                                 {% endfor %}
-                                {% for item in starting_items_single %}
+                                {% for item in item_names_single %}
                                     <div class="form-group row my-2">
                                         <label class="col-sm-2 col-form-label text-end" for="starting_item_{{+ item }}">{{+ item }}</label>
                                         <div id="startingItem{{ item}}" class="col-sm-3 btn-group" role="group">

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -848,7 +848,7 @@ function applyItemProgressionPreset(preset) {
     
     /* Preset all uniques to true (upgrade previous presets which lacked these) */
     
-    {% for item in item_pool_single %}
+    {% for item in item_names_single %}
     document.getElementById("itemPool{{+ item }}Yes").checked = true;
     {% endfor %}
     
@@ -908,10 +908,10 @@ function itemProgressionChanged() {
 }
 function processStartingItemsPreset() {
     if (document.getElementById("startingItemsPresetNone").checked) {
-        {% for item in starting_items_multiple %}
+        {% for item in item_names_multiple %}
         document.getElementById("startingItem{{+ item }}").value = "0";
         {% endfor %}
-        {% for item in starting_items_single %}
+        {% for item in item_names_single %}
         document.getElementById("startingItem{{+ item }}No").checked = true;
         {% endfor %}
     }
@@ -921,7 +921,7 @@ function processStartingItemsPreset() {
         document.getElementById("startingItemReserveTank").value = "4";
         document.getElementById("startingItemSuper").value = "10";
         document.getElementById("startingItemPowerBomb").value = "10";
-        {% for item in starting_items_single %}
+        {% for item in item_names_single %}
         document.getElementById("startingItem{{+ item }}Yes").checked = true;
         {% endfor %}
     }
@@ -962,7 +962,7 @@ function processItemPoolPreset() {
         document.getElementById("itemPoolPowerBomb").value = "10";
         document.getElementById("itemPoolETank").value = "14";
         document.getElementById("itemPoolReserveTank").value = "4";
-        {% for item in item_pool_single %}
+        {% for item in item_names_single %}
         document.getElementById("itemPool{{+ item }}Yes").checked = true;
         {% endfor %}
     }
@@ -973,7 +973,7 @@ function processItemPoolPreset() {
         document.getElementById("itemPoolPowerBomb").value = "5";
         document.getElementById("itemPoolETank").value = "3";
         document.getElementById("itemPoolReserveTank").value = "3";
-        {% for item in item_pool_single %}
+        {% for item in item_names_single %}
         document.getElementById("itemPool{{+ item }}Yes").checked = true;
         {% endfor %}
     }

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -345,6 +345,16 @@ function buildItemPool() {
         name = x.name.substring(10);
         itemPool.push({"item": name, "count": tryParseInt(x.value)});
     });
+    document.querySelectorAll('.item-pool-input-single')
+    .forEach(function (x) {
+        // remove prefix: 'item_pool_"
+        name = x.name.substring(10);
+        if (x.checked && x.value == "Yes") {
+            itemPool.push({"item": name, "count": 1});
+        } else if (x.checked && x.value == "No") {
+            itemPool.push({"item": name, "count": 0});
+        }
+    });
     return itemPool;
 }
 function buildStartingItems() {
@@ -835,10 +845,22 @@ function applyItemProgressionPreset(preset) {
     applyRadioValue("itemPoolPreset", preset.item_pool_preset);
     applyRadioValue("stopItemPlacementEarly", preset.stop_item_placement_early);
     document.getElementById("ammoCollectFraction").value = preset.ammo_collect_fraction;
+    
+    /* Preset all uniques to true (upgrade previous presets which lacked these) */
+    
+    {% for item in item_pool_single %}
+    document.getElementById("itemPool{{+ item }}Yes").checked = true;
+    {% endfor %}
+    
     for (x of preset.item_pool) {
         let item = x.item;
         let cnt = x.count;
-        document.getElementById(`itemPool${item}`).value = cnt;
+	let el = document.getElementById(`itemPool${item}`);
+	if (el.classList.contains("item-pool-input-multiple")) {
+		el.value = cnt;
+	} else {
+		applyRadioValue(`itemPool${item}`, cnt > 0 ? "Yes" : "No");
+	}
     }
     processItemPoolPreset();
     applyRadioValue("startingItemsPreset", preset.starting_items_preset);
@@ -940,6 +962,9 @@ function processItemPoolPreset() {
         document.getElementById("itemPoolPowerBomb").value = "10";
         document.getElementById("itemPoolETank").value = "14";
         document.getElementById("itemPoolReserveTank").value = "4";
+        {% for item in item_pool_single %}
+        document.getElementById("itemPool{{+ item }}Yes").checked = true;
+        {% endfor %}
     }
     if (document.getElementById("itemPoolPresetReduced").checked) {
         document.getElementById("stopItemPlacementEarlyYes").checked = true;
@@ -948,11 +973,14 @@ function processItemPoolPreset() {
         document.getElementById("itemPoolPowerBomb").value = "5";
         document.getElementById("itemPoolETank").value = "3";
         document.getElementById("itemPoolReserveTank").value = "3";
+        {% for item in item_pool_single %}
+        document.getElementById("itemPool{{+ item }}Yes").checked = true;
+        {% endfor %}
     }
 }
 function validateItemPool() {
-    if (parseInt(document.getElementById("itemPoolMissile").value) > 46) {
-        document.getElementById("itemPoolMissile").value = "46";
+    if (parseInt(document.getElementById("itemPoolMissile").value) > 100) {
+        document.getElementById("itemPoolMissile").value = "100";
     }
     if (parseInt(document.getElementById("itemPoolETank").value) > 14) {
         document.getElementById("itemPoolETank").value = "14";
@@ -967,20 +995,20 @@ function validateItemPool() {
         document.getElementById("itemPoolPowerBomb").value = "19";
     }
 
-    if (parseInt(document.getElementById("itemPoolMissile").value) < 2) {
-        document.getElementById("itemPoolMissile").value = "2";
+    if (parseInt(document.getElementById("itemPoolMissile").value) < 0) {
+        document.getElementById("itemPoolMissile").value = "0";
     }
-    if (parseInt(document.getElementById("itemPoolETank").value) < 2) {
-        document.getElementById("itemPoolETank").value = "2";
+    if (parseInt(document.getElementById("itemPoolETank").value) < 0) {
+        document.getElementById("itemPoolETank").value = "0";
     }
-    if (parseInt(document.getElementById("itemPoolReserveTank").value) < 1) {
-        document.getElementById("itemPoolReserveTank").value = "1";
+    if (parseInt(document.getElementById("itemPoolReserveTank").value) < 0) {
+        document.getElementById("itemPoolReserveTank").value = "0";
     }
-    if (parseInt(document.getElementById("itemPoolSuper").value) < 2) {
-        document.getElementById("itemPoolSuper").value = "2";
+    if (parseInt(document.getElementById("itemPoolSuper").value) < 0) {
+        document.getElementById("itemPoolSuper").value = "0";
     }
-    if (parseInt(document.getElementById("itemPoolPowerBomb").value) < 1) {
-        document.getElementById("itemPoolPowerBomb").value = "1";
+    if (parseInt(document.getElementById("itemPoolPowerBomb").value) < 0) {
+        document.getElementById("itemPoolPowerBomb").value = "0";
     }
 }
 function itemPoolPresetChanged() {

--- a/rust/maprando/src/helpers.rs
+++ b/rust/maprando/src/helpers.rs
@@ -10,7 +10,6 @@ pub fn get_item_priorities(item_priorities: &[KeyItemPrioritySetting]) -> Vec<It
     priorities.add(&KeyItemPriority::Early);
     priorities.add(&KeyItemPriority::Default);
     priorities.add(&KeyItemPriority::Late);
-    priorities.add(&KeyItemPriority::Never);
 
     let mut out: Vec<ItemPriorityGroup> = Vec::new();
     for &priority in &priorities.keys {

--- a/rust/maprando/src/patch.rs
+++ b/rust/maprando/src/patch.rs
@@ -2105,7 +2105,7 @@ impl Patcher<'_> {
                     ItemCount {
                         item: Item::WallJump,
                         count: 1,
-                    }
+                    },
                 ]
                 .into_iter()
                 .collect()
@@ -2118,7 +2118,11 @@ impl Patcher<'_> {
 
         for x in &starting_items {
             // Skip WJB without CWJ
-            if x.item == Item::WallJump && self.settings.other_settings.wall_jump == WallJump::Vanilla { continue }
+            if x.item == Item::WallJump
+                && self.settings.other_settings.wall_jump == WallJump::Vanilla
+            {
+                continue;
+            }
             if x.count == 0 {
                 continue;
             }

--- a/rust/maprando/src/patch.rs
+++ b/rust/maprando/src/patch.rs
@@ -1997,6 +1997,7 @@ impl Patcher<'_> {
             (Item::Gravity, 0x0020),
             (Item::HiJump, 0x0100),
             (Item::SpaceJump, 0x0200),
+            (Item::WallJump, 0x0400),
             (Item::Bombs, 0x1000),
             (Item::SpeedBooster, 0x2000),
             (Item::Grapple, 0x4000),
@@ -2101,6 +2102,10 @@ impl Patcher<'_> {
                         item: Item::ReserveTank,
                         count: 4,
                     },
+                    ItemCount {
+                        item: Item::WallJump,
+                        count: 1,
+                    }
                 ]
                 .into_iter()
                 .collect()
@@ -2112,6 +2117,8 @@ impl Patcher<'_> {
             };
 
         for x in &starting_items {
+            // Skip WJB without CWJ
+            if x.item == Item::WallJump && self.settings.other_settings.wall_jump == WallJump::Vanilla { continue }
             if x.count == 0 {
                 continue;
             }

--- a/rust/maprando/src/randomize.rs
+++ b/rust/maprando/src/randomize.rs
@@ -4179,7 +4179,11 @@ impl<'r> Randomizer<'r> {
         for x in &settings.item_progression_settings.starting_items {
             if x.count > 0 {
                 // Skip WJB if it appears in the starting items without CWJ
-                if x.item == Item::WallJump && settings.other_settings.wall_jump == WallJump::Vanilla { continue }
+                if x.item == Item::WallJump
+                    && settings.other_settings.wall_jump == WallJump::Vanilla
+                {
+                    continue;
+                }
                 item_spoiler_info.push(EssentialItemSpoilerInfo {
                     item: x.item,
                     step: Some(0),
@@ -4621,7 +4625,11 @@ impl<'r> Randomizer<'r> {
         };
         let mut local = LocalState::empty(&global);
         for x in &self.settings.item_progression_settings.starting_items {
-            if x.item == Item::WallJump && self.settings.other_settings.wall_jump == WallJump::Vanilla { continue }
+            if x.item == Item::WallJump
+                && self.settings.other_settings.wall_jump == WallJump::Vanilla
+            {
+                continue;
+            }
             for _ in 0..x.count {
                 global.collect(
                     x.item,

--- a/rust/maprando/src/randomize.rs
+++ b/rust/maprando/src/randomize.rs
@@ -3161,13 +3161,6 @@ impl<'r> Randomizer<'r> {
             initial_items_remaining[Item::ETank as usize] += 1;
         }
 
-        for kip in settings.item_progression_settings.key_item_priority.iter() {
-            if kip.priority == KeyItemPriority::Never {
-                // Items set to 'Never' are removed from the pool.
-                initial_items_remaining[kip.item as usize] = 0;
-            }
-        }
-
         let target_initial_items = initial_items_remaining.clone();
         let ammo_shortage_weight: Vec<(Item, f32)> = vec![
             (Item::Missile, 0.12),
@@ -3521,6 +3514,7 @@ impl<'r> Randomizer<'r> {
                 item_types_to_extra_delay.push(item);
             }
         }
+
         let mut items_to_mix: Vec<Item> = Vec::new();
         for &item in &item_types_to_mix {
             let mut cnt = state.items_remaining[item as usize];
@@ -4314,12 +4308,9 @@ impl<'r> Randomizer<'r> {
         }
         match item_priority_strength {
             ItemPriorityStrength::Moderate => {
-                assert!(item_priorities.len() == 4);
+                assert!(item_priorities.len() == 3);
                 let mut items = vec![];
                 for (i, priority_group) in item_priorities.iter().enumerate() {
-                    if priority_group.priority == KeyItemPriority::Never {
-                        continue;
-                    }
                     for item_name in &priority_group.items {
                         items.push(item_name.clone());
                         if i != 1 {
@@ -4351,9 +4342,6 @@ impl<'r> Randomizer<'r> {
             }
             ItemPriorityStrength::Heavy => {
                 for priority_group in item_priorities {
-                    if priority_group.priority == KeyItemPriority::Never {
-                        continue;
-                    }
                     let mut items = priority_group.items.clone();
                     items.shuffle(rng);
                     for item_name in &items {

--- a/rust/maprando/src/randomize.rs
+++ b/rust/maprando/src/randomize.rs
@@ -4178,7 +4178,7 @@ impl<'r> Randomizer<'r> {
         // Include starting items first, as "step 0":
         for x in &settings.item_progression_settings.starting_items {
             if x.count > 0 {
-                // Skip WJB if it appears in the starting items without CWJ
+                // Skip WallJump if it appears in the starting items without Collectible wall jump
                 if x.item == Item::WallJump
                     && settings.other_settings.wall_jump == WallJump::Vanilla
                 {

--- a/rust/maprando/src/randomize.rs
+++ b/rust/maprando/src/randomize.rs
@@ -3135,14 +3135,11 @@ impl<'r> Randomizer<'r> {
 
         let mut initial_items_remaining: Vec<usize> = vec![1; game_data.item_isv.keys.len()];
         initial_items_remaining[Item::Nothing as usize] = 0;
-        initial_items_remaining[Item::WallJump as usize] =
-            if settings.other_settings.wall_jump == WallJump::Collectible {
-                1
-            } else {
-                0
-            };
         for x in &settings.item_progression_settings.item_pool {
             initial_items_remaining[x.item as usize] = x.count;
+        }
+        if settings.other_settings.wall_jump == WallJump::Vanilla {
+            initial_items_remaining[Item::WallJump as usize] = 0;
         }
 
         let mut minimal_tank_count = get_minimal_tank_count(&difficulty_tiers[0]);
@@ -4181,6 +4178,8 @@ impl<'r> Randomizer<'r> {
         // Include starting items first, as "step 0":
         for x in &settings.item_progression_settings.starting_items {
             if x.count > 0 {
+                // Skip WJB if it appears in the starting items without CWJ
+                if x.item == Item::WallJump && settings.other_settings.wall_jump == WallJump::Vanilla { continue }
                 item_spoiler_info.push(EssentialItemSpoilerInfo {
                     item: x.item,
                     step: Some(0),
@@ -4622,6 +4621,7 @@ impl<'r> Randomizer<'r> {
         };
         let mut local = LocalState::empty(&global);
         for x in &self.settings.item_progression_settings.starting_items {
+            if x.item == Item::WallJump && self.settings.other_settings.wall_jump == WallJump::Vanilla { continue }
             for _ in 0..x.count {
                 global.collect(
                     x.item,

--- a/rust/maprando/src/settings.rs
+++ b/rust/maprando/src/settings.rs
@@ -374,7 +374,6 @@ pub enum KeyItemPriority {
     #[default]
     Default,
     Late,
-    Never,
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Expands the Item Pool UI element to allow toggling unique items.

This will replace part (or perhaps all) of the prior `Never` feature in this particular role. `Never` can be either repurposed to target key item placement only, or removed in favor of this approach.