### PR TITLE
Add UI support for 'greyed out' controls

### DIFF
--- a/rust/maprando-web/templates/generate/item_progression.html
+++ b/rust/maprando-web/templates/generate/item_progression.html
@@ -280,7 +280,7 @@
                 </div>
 
 
-                <div class="row m-2">
+                <div class="row m-2" id="itemPriorities">
                     <div class="col-lg-6">
                         <div class="card">
                             <div class="card-header px-2">

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -1069,6 +1069,30 @@ function showError(e) {
     errorModal.show();
 }
 
+function setButtonConflicted(element) {
+    //element.classList.remove("btn-outline-primary");
+    element.classList.add("btn-outline-conflict");
+}
+
+function setButtonNoConflict(element) {
+    //element.classList.add("btn-outline-primary");
+    element.classList.remove("btn-outline-conflict");
+}
+
+function updateFormConflicts() {
+    if (document.getElementById("startLocationEscape").checked) {
+        document.querySelectorAll(":is(#itemProgressionPreset,#objectives,#doors) label").forEach(setButtonConflicted);
+    } else {
+        document.querySelectorAll(":is(#itemProgressionPreset,#objectives,#doors) label").forEach(setButtonNoConflict);
+    }
+
+    if (document.getElementById("wallJumpVanilla").checked) {
+        document.querySelectorAll(".itemIconWallJump ~ div>label").forEach(setButtonConflicted);
+    } else if (document.getElementById("wallJumpCollectible").checked) {
+        document.querySelectorAll(".itemIconWallJump ~ div>label").forEach(setButtonNoConflict);
+    }
+}
+
 async function loadSettings() {
     let settings = await localforage.getItem("generateSettings");
 
@@ -1109,9 +1133,13 @@ async function loadSettings() {
         }
     }
     checkOtherOptions();
+    
+    updateFormConflicts();
 }
 
 async function saveSettings() {
+    updateFormConflicts();
+
     let settings = buildSettingsObject();
     await localforage.setItem("generateSettings", settings);
 }
@@ -1360,3 +1388,21 @@ window.addEventListener('pageshow', (event) => {
   }
 });
 </script>
+<style>
+.btn-outline-conflict {
+    --bs-btn-color: #6c757d;
+    --bs-btn-border-color: #6c757d;
+    --bs-btn-hover-color: #fff;
+    --bs-btn-hover-bg: #6c757d;
+    --bs-btn-hover-border-color: #6c757d;
+    --bs-btn-focus-shadow-rgb: 108, 117, 125;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #6c757d;
+    --bs-btn-active-border-color: #6c757d;
+    --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+    --bs-btn-disabled-color: #6c757d;
+    --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: #6c757d;
+    --bs-gradient: none;
+}
+</style>

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -1070,20 +1070,18 @@ function showError(e) {
 }
 
 function setButtonConflicted(element) {
-    //element.classList.remove("btn-outline-primary");
     element.classList.add("btn-outline-conflict");
 }
 
 function setButtonNoConflict(element) {
-    //element.classList.add("btn-outline-primary");
     element.classList.remove("btn-outline-conflict");
 }
 
 function updateFormConflicts() {
     if (document.getElementById("startLocationEscape").checked) {
-        document.querySelectorAll(":is(#itemProgressionPreset,#objectives,#doors) label").forEach(setButtonConflicted);
+        document.querySelectorAll("#itemProgressionPreset label").forEach(setButtonConflicted);
     } else {
-        document.querySelectorAll(":is(#itemProgressionPreset,#objectives,#doors) label").forEach(setButtonNoConflict);
+        document.querySelectorAll("#itemProgressionPreset label").forEach(setButtonNoConflict);
     }
 
     if (document.getElementById("wallJumpVanilla").checked) {

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -1113,6 +1113,10 @@ function updateFormConflicts() {
     if (parseInt(document.getElementById("itemPoolPowerBomb").value) < 1) {
         document.querySelectorAll("#itemPriorities .itemIconPowerBomb ~ div>label").forEach(Set.prototype.add.bind(toAdd));
     }
+    
+    if (document.getElementById("itemPoolSpazerNo").checked || document.getElementById("itemPoolPlasmaNo").checked) {
+        document.querySelectorAll("#spazerBeforePlasma label").forEach(Set.prototype.add.bind(toAdd));
+    }
 
     {% for item in item_names_single %}
     if (document.getElementById("itemPool{{+ item }}No").checked) {

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -927,8 +927,8 @@ function processStartingItemsPreset() {
     }
 }
 function validateStartingItems() {
-    if (parseInt(document.getElementById("startingItemMissile").value) > 46) {
-        document.getElementById("startingItemMissile").value = "46";
+    if (parseInt(document.getElementById("startingItemMissile").value) > 199) {
+        document.getElementById("startingItemMissile").value = "199";
     }
     if (parseInt(document.getElementById("startingItemETank").value) > 14) {
         document.getElementById("startingItemETank").value = "14";
@@ -936,11 +936,26 @@ function validateStartingItems() {
     if (parseInt(document.getElementById("startingItemReserveTank").value) > 4) {
         document.getElementById("startingItemReserveTank").value = "4";
     }
-    if (parseInt(document.getElementById("startingItemSuper").value) > 10) {
-        document.getElementById("startingItemSuper").value = "10";
+    if (parseInt(document.getElementById("startingItemSuper").value) > 19) {
+        document.getElementById("startingItemSuper").value = "19";
     }
-    if (parseInt(document.getElementById("startingItemPowerBomb").value) > 10) {
+    if (parseInt(document.getElementById("startingItemPowerBomb").value) > 19) {
         document.getElementById("startingItemPowerBomb").value = "10";
+    }
+    if (parseInt(document.getElementById("startingItemMissile").value) < 0) {
+        document.getElementById("startingItemMissile").value = "0";
+    }
+    if (parseInt(document.getElementById("startingItemETank").value) < 0) {
+        document.getElementById("startingItemETank").value = "0";
+    }
+    if (parseInt(document.getElementById("startingItemReserveTank").value) < 0) {
+        document.getElementById("startingItemReserveTank").value = "0";
+    }
+    if (parseInt(document.getElementById("startingItemSuper").value) < 0) {
+        document.getElementById("startingItemSuper").value = "0";
+    }
+    if (parseInt(document.getElementById("startingItemPowerBomb").value) < 0) {
+        document.getElementById("startingItemPowerBomb").value = "0";
     }
 }
 function startingItemsPresetChanged() {

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -994,8 +994,8 @@ function processItemPoolPreset() {
     }
 }
 function validateItemPool() {
-    if (parseInt(document.getElementById("itemPoolMissile").value) > 100) {
-        document.getElementById("itemPoolMissile").value = "100";
+    if (parseInt(document.getElementById("itemPoolMissile").value) > 199) {
+        document.getElementById("itemPoolMissile").value = "199";
     }
     if (parseInt(document.getElementById("itemPoolETank").value) > 14) {
         document.getElementById("itemPoolETank").value = "14";

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -1117,6 +1117,10 @@ function updateFormConflicts() {
     if (document.getElementById("itemPoolSpazerNo").checked || document.getElementById("itemPoolPlasmaNo").checked) {
         document.querySelectorAll("#spazerBeforePlasma label").forEach(Set.prototype.add.bind(toAdd));
     }
+    
+    if (document.getElementById("stopItemPlacementEarlyYes").checked) {
+        document.querySelectorAll("#escapeMovementItems label").forEach(Set.prototype.add.bind(toAdd));
+    }
 
     {% for item in item_names_single %}
     if (document.getElementById("itemPool{{+ item }}No").checked) {

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -1069,26 +1069,47 @@ function showError(e) {
     errorModal.show();
 }
 
-function setButtonConflicted(element) {
-    element.classList.add("btn-outline-conflict");
-}
-
-function setButtonNoConflict(element) {
-    element.classList.remove("btn-outline-conflict");
-}
-
 function updateFormConflicts() {
+    const current = new Set();
+    document.querySelectorAll(".btn-outline-conflict").forEach(Set.prototype.add.bind(current));
+    
+    const toAdd = new Set();
+
     if (document.getElementById("startLocationEscape").checked) {
-        document.querySelectorAll("#itemProgressionPreset label").forEach(setButtonConflicted);
-    } else {
-        document.querySelectorAll("#itemProgressionPreset label").forEach(setButtonNoConflict);
+        document.querySelectorAll("#itemProgressionPreset label").forEach(Set.prototype.add.bind(toAdd));
     }
 
     if (document.getElementById("wallJumpVanilla").checked) {
-        document.querySelectorAll(".itemIconWallJump ~ div>label").forEach(setButtonConflicted);
-    } else if (document.getElementById("wallJumpCollectible").checked) {
-        document.querySelectorAll(".itemIconWallJump ~ div>label").forEach(setButtonNoConflict);
+        document.querySelectorAll(".itemIconWallJump ~ div>label").forEach(Set.prototype.add.bind(toAdd));
     }
+    
+    if (parseInt(document.getElementById("itemPoolMissile").value) < 1) {
+        document.querySelectorAll("#itemPriorities .itemIconMissile ~ div>label").forEach(Set.prototype.add.bind(toAdd));
+    }
+    if (parseInt(document.getElementById("itemPoolETank").value) < 1) {
+        document.querySelectorAll("#itemPriorities .itemIconETank ~ div>label").forEach(Set.prototype.add.bind(toAdd));
+    }
+    if (parseInt(document.getElementById("itemPoolReserveTank").value) < 1) {
+        document.querySelectorAll("#itemPriorities .itemIconReserveTank ~ div>label").forEach(Set.prototype.add.bind(toAdd));
+    }
+    if (parseInt(document.getElementById("itemPoolSuper").value) < 1) {
+        document.querySelectorAll("#itemPriorities .itemIconSuper ~ div>label").forEach(Set.prototype.add.bind(toAdd));
+    }
+    if (parseInt(document.getElementById("itemPoolPowerBomb").value) < 1) {
+        document.querySelectorAll("#itemPriorities .itemIconPowerBomb ~ div>label").forEach(Set.prototype.add.bind(toAdd));
+    }
+
+    {% for item in item_names_single %}
+    if (document.getElementById("itemPool{{+ item }}No").checked) {
+        document.querySelectorAll("#itemPriorities .itemIcon{{+ item }} ~ div>label").forEach(Set.prototype.add.bind(toAdd));
+    }
+    {% endfor %}
+    
+    let toRemove = current.difference(toAdd);
+    
+    toAdd.forEach(element => { element.classList.add("btn-outline-conflict"); });
+    toRemove.forEach(element => { element.classList.remove("btn-outline-conflict"); });
+
 }
 
 async function loadSettings() {


### PR DESCRIPTION
This is used to indicate options that have no effect due to other settings. Examples:

- WallJump options in the item pool/starting item/priority lists when "Collectible WallJump" is not selected
- Item Progression (presets only - currently not the entire modal), Objectives, Doors when selecting an Escape start.