### PR TITLE
fix double toilet in Pants Room

### DIFF
--- a/rust/maprando/src/bin/build-mosaic.rs
+++ b/rust/maprando/src/bin/build-mosaic.rs
@@ -1210,7 +1210,7 @@ impl MosaicPatchBuilder {
 
                             if let Some(twin_state_xml) = twin_state_xml.as_ref()
                                 && room_geometry.name != "Aqueduct"
-                                && (room_idx != 138 || x == 0)
+                                && (room_idx != 138 || x == 1)
                             {
                                 let twin_room_ptr = if room_idx == 138 { 0x7D69A } else { 0x7968F };
                                 self.write_toilet_intersection_room(


### PR DESCRIPTION
Patch to force toilet/pants room intersection during generation:

```
diff --git a/rust/maprando-game/src/lib.rs b/rust/maprando-game/src/lib.rs
index bf98fb0ea..800a17411 100644
--- a/rust/maprando-game/src/lib.rs
+++ b/rust/maprando-game/src/lib.rs
@@ -1526,6 +1526,7 @@ pub struct GameData {
     pub ship_room_idx: usize,
     pub mother_brain_room_idx: usize,
     pub toilet_room_idx: usize,
+    pub pants_room_idx: usize,
     pub node_tile_coords: HashMap<(RoomId, NodeId), Vec<(usize, usize)>>,
     pub node_coords: HashMap<(RoomId, NodeId), (usize, usize)>,
     pub room_shape: HashMap<RoomId, (usize, usize)>,
@@ -5137,6 +5138,9 @@ impl GameData {
             if room.name == "Toilet" {
                 self.toilet_room_idx = room_idx;
             }
+            if room.name == "Pants Room" {
+                self.pants_room_idx = room_idx;
+            }
             if room.name == "Landing Site" {
                 self.ship_room_idx = room_idx;
             }
diff --git a/rust/maprando/src/bin/build-mosaic.rs b/rust/maprando/src/bin/build-mosaic.rs
index 5bb7b2afc..33798b87d 100644
--- a/rust/maprando/src/bin/build-mosaic.rs
+++ b/rust/maprando/src/bin/build-mosaic.rs
@@ -1210,7 +1210,7 @@ impl MosaicPatchBuilder {

                             if let Some(twin_state_xml) = twin_state_xml.as_ref()
                                 && room_geometry.name != "Aqueduct"
-                                && (room_idx != 138 || x == 0)
+                                && (room_idx != 138 || x == 1)
                             {
                                 let twin_room_ptr = if room_idx == 138 { 0x7D69A } else { 0x7968F };
                                 self.write_toilet_intersection_room(
diff --git a/rust/maprando/src/map_repository.rs b/rust/maprando/src/map_repository.rs
index c6ec766a8..3b5ee9625 100644
--- a/rust/maprando/src/map_repository.rs
+++ b/rust/maprando/src/map_repository.rs
@@ -135,6 +135,9 @@ impl MapRepository {
             // TODO: Push this upstream into the map generation
             let toilet_intersections = Randomizer::get_toilet_intersections(&map, game_data);
             if !toilet_intersections.is_empty() {
+                if seed !=0 && !&toilet_intersections.contains(&game_data.pants_room_idx) {
+                    continue;
+                }
                 let area = map.area[toilet_intersections[0]];
                 let subarea = map.subarea[toilet_intersections[0]];
                 let subsubarea = map.subsubarea[toilet_intersections[0]];
```
