### PR TITLE
move extra setup to the base patches.

### DIFF
--- a/rust/maprando/src/patch.rs
+++ b/rust/maprando/src/patch.rs
@@ -442,6 +442,7 @@ impl Patcher<'_> {
             "complementary_suits",
             "disable_map_icons",
             "escape",
+            "extra_setup",
             "tourian_map",                 // TODO: check if this is still needed?
             "no_explosions_before_escape", // TODO: check if this is still needed?
             "sound_effect_disables",
@@ -483,7 +484,6 @@ impl Patcher<'_> {
                 "fix_kraid_hud",
                 "fix_kraid_door",
                 "boss_exit",
-                "extra_setup",
                 "load_plms_early",
                 "spin_lock",
                 "fix_transition_bad_tiles",


### PR DESCRIPTION
Just noticed i'd put this in the "if ultralow QOL is not enabled section".. it should go in the base patches (where hazard markers was before i moved it) otherwise ultralow QOL doors will also be broken.