### PR TITLE
Filter walljump boots / speedboosters depending on options

### DIFF
--- a/rust/maprando-web/src/randomize_helpers.rs
+++ b/rust/maprando-web/src/randomize_helpers.rs
@@ -405,6 +405,7 @@ pub fn render_seed(
                 .settings
                 .item_progression_settings
                 .key_item_priority,
+            &seed_data.settings.other_settings,
         ),
         objective_names,
         race_mode: seed_data.race_mode,

--- a/rust/maprando/src/helpers.rs
+++ b/rust/maprando/src/helpers.rs
@@ -1,11 +1,14 @@
-use maprando_game::IndexedVec;
-
 use crate::{
     randomize::ItemPriorityGroup,
-    settings::{KeyItemPriority, KeyItemPrioritySetting},
+    settings::{KeyItemPriority, KeyItemPrioritySetting, OtherSettings, SpeedBooster, WallJump},
 };
+use maprando_game::IndexedVec;
+use maprando_game::Item;
 
-pub fn get_item_priorities(item_priorities: &[KeyItemPrioritySetting]) -> Vec<ItemPriorityGroup> {
+pub fn get_item_priorities(
+    item_priorities: &[KeyItemPrioritySetting],
+    other_settings: &OtherSettings,
+) -> Vec<ItemPriorityGroup> {
     let mut priorities: IndexedVec<KeyItemPriority> = IndexedVec::default();
     priorities.add(&KeyItemPriority::Early);
     priorities.add(&KeyItemPriority::Default);
@@ -19,6 +22,19 @@ pub fn get_item_priorities(item_priorities: &[KeyItemPrioritySetting]) -> Vec<It
         });
     }
     for x in item_priorities {
+        if other_settings.wall_jump == WallJump::Vanilla && x.item == Item::WallJump {
+            continue;
+        }
+
+        if other_settings.speed_booster == SpeedBooster::Vanilla
+            && (x.item == Item::SparkBooster || x.item == Item::BlueBooster)
+        {
+            continue;
+        }
+
+        if other_settings.speed_booster == SpeedBooster::Split && x.item == Item::SpeedBooster {
+            continue;
+        }
         let i = priorities.index_by_key[&x.priority];
         out[i].items.push(format!("{:?}", x.item));
     }

--- a/rust/maprando/src/randomize.rs
+++ b/rust/maprando/src/randomize.rs
@@ -3789,6 +3789,7 @@ impl<'r> Randomizer<'r> {
             filler_priority_map,
             item_priority_groups: get_item_priorities(
                 &settings.item_progression_settings.key_item_priority,
+                &settings.other_settings,
             ),
             base_links_data,
             seed_links_data: LinksDataGroup::new(


### PR DESCRIPTION
saw this on the "todo.txt"

removes walljump / split speed / speedbooster if the option isnt' on from the seed page.

might be more elegant way to do the rust.. 

<img width="2730" height="1906" alt="items" src="https://github.com/user-attachments/assets/1dea206a-ecc2-442a-8516-ea6aa60d7bf4" />
