### PR TITLE
Update Item Pool UI limits

### DIFF
--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -1290,20 +1290,20 @@ function processStartingItemsPreset() {
     }
 }
 function validateStartingItems() {
-    if (parseInt(document.getElementById("startingItemMissile").value) > 100) {
-        document.getElementById("startingItemMissile").value = "100";
+    if (parseInt(document.getElementById("startingItemMissile").value) > 999) {
+        document.getElementById("startingItemMissile").value = "999";
     }
-    if (parseInt(document.getElementById("startingItemETank").value) > 100) {
-        document.getElementById("startingItemETank").value = "100";
+    if (parseInt(document.getElementById("startingItemETank").value) > 14) {
+        document.getElementById("startingItemETank").value = "14";
     }
-    if (parseInt(document.getElementById("startingItemReserveTank").value) > 100) {
-        document.getElementById("startingItemReserveTank").value = "100";
+    if (parseInt(document.getElementById("startingItemReserveTank").value) > 4) {
+        document.getElementById("startingItemReserveTank").value = "4";
     }
-    if (parseInt(document.getElementById("startingItemSuper").value) > 100) {
-        document.getElementById("startingItemSuper").value = "100";
+    if (parseInt(document.getElementById("startingItemSuper").value) > 99) {
+        document.getElementById("startingItemSuper").value = "99";
     }
-    if (parseInt(document.getElementById("startingItemPowerBomb").value) > 100) {
-        document.getElementById("startingItemPowerBomb").value = "100";
+    if (parseInt(document.getElementById("startingItemPowerBomb").value) > 99) {
+        document.getElementById("startingItemPowerBomb").value = "99";
     }
     if (parseInt(document.getElementById("startingItemMissile").value) < 0) {
         document.getElementById("startingItemMissile").value = "0";

--- a/rust/maprando-web/templates/generate/scripts.html
+++ b/rust/maprando-web/templates/generate/scripts.html
@@ -1290,20 +1290,20 @@ function processStartingItemsPreset() {
     }
 }
 function validateStartingItems() {
-    if (parseInt(document.getElementById("startingItemMissile").value) > 199) {
-        document.getElementById("startingItemMissile").value = "199";
+    if (parseInt(document.getElementById("startingItemMissile").value) > 100) {
+        document.getElementById("startingItemMissile").value = "100";
     }
-    if (parseInt(document.getElementById("startingItemETank").value) > 14) {
-        document.getElementById("startingItemETank").value = "14";
+    if (parseInt(document.getElementById("startingItemETank").value) > 100) {
+        document.getElementById("startingItemETank").value = "100";
     }
-    if (parseInt(document.getElementById("startingItemReserveTank").value) > 4) {
-        document.getElementById("startingItemReserveTank").value = "4";
+    if (parseInt(document.getElementById("startingItemReserveTank").value) > 100) {
+        document.getElementById("startingItemReserveTank").value = "100";
     }
-    if (parseInt(document.getElementById("startingItemSuper").value) > 19) {
-        document.getElementById("startingItemSuper").value = "19";
+    if (parseInt(document.getElementById("startingItemSuper").value) > 100) {
+        document.getElementById("startingItemSuper").value = "100";
     }
-    if (parseInt(document.getElementById("startingItemPowerBomb").value) > 19) {
-        document.getElementById("startingItemPowerBomb").value = "19";
+    if (parseInt(document.getElementById("startingItemPowerBomb").value) > 100) {
+        document.getElementById("startingItemPowerBomb").value = "100";
     }
     if (parseInt(document.getElementById("startingItemMissile").value) < 0) {
         document.getElementById("startingItemMissile").value = "0";
@@ -1402,20 +1402,20 @@ function validatePickupSize() {
 }
 
 function validateItemPool() {
-    if (parseInt(document.getElementById("itemPoolMissile").value) > 999) {
-        document.getElementById("itemPoolMissile").value = "999";
+    if (parseInt(document.getElementById("itemPoolMissile").value) > 1099) {
+        document.getElementById("itemPoolMissile").value = "1099";
     }
-    if (parseInt(document.getElementById("itemPoolETank").value) > 14) {
-        document.getElementById("itemPoolETank").value = "14";
+    if (parseInt(document.getElementById("itemPoolETank").value) > 114) {
+        document.getElementById("itemPoolETank").value = "114";
     }
-    if (parseInt(document.getElementById("itemPoolReserveTank").value) > 4) {
-        document.getElementById("itemPoolReserveTank").value = "4";
+    if (parseInt(document.getElementById("itemPoolReserveTank").value) > 104) {
+        document.getElementById("itemPoolReserveTank").value = "104";
     }
-    if (parseInt(document.getElementById("itemPoolSuper").value) > 99) {
-        document.getElementById("itemPoolSuper").value = "99";
+    if (parseInt(document.getElementById("itemPoolSuper").value) > 199) {
+        document.getElementById("itemPoolSuper").value = "199";
     }
-    if (parseInt(document.getElementById("itemPoolPowerBomb").value) > 99) {
-        document.getElementById("itemPoolPowerBomb").value = "99";
+    if (parseInt(document.getElementById("itemPoolPowerBomb").value) > 199) {
+        document.getElementById("itemPoolPowerBomb").value = "199";
     }
 
     if (parseInt(document.getElementById("itemPoolMissile").value) < 0) {


### PR DESCRIPTION
Updates the limits on the Item Pool fields, now that the HUD can't be overloaded.

The new caps are best effort "values above this just aren't useful for generation": they are based on the maximum starting item count (which is, itself, based on the HUD limits), plus 100, such that it is possible to have a Starting Item set with every item PLUS maxxed out HUD limit on all resources, and still be able to populate all 100 locations on the map with resources (which would only refill if you're starting at HUD cap).